### PR TITLE
Formal "cohorts" concept

### DIFF
--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -53,5 +53,6 @@ function(fenix_test)
   endif()
 
   set_tests_properties(${args_TESTNAME} PROPERTIES
-    FAIL_REGULAR_EXPRESSION "${fail_regex}")
+    FAIL_REGULAR_EXPRESSION "${fail_regex}"
+    TIMEOUT 10)
 endfunction()

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -104,11 +104,13 @@ typedef enum {
   FENIX_ERROR_MEMBER_EXISTS,
   FENIX_ERROR_MEMBER_STAGING,
   FENIX_ERROR_MEMBER_LOADING,
+  FENIX_ERROR_MEMBER_UNSTORED,
   FENIX_ERROR_COMMIT_BARRIER,
   FENIX_ERROR_INVALID_GROUPID,
   FENIX_ERROR_INVALID_MEMBERID,
   FENIX_ERROR_INVALID_LOGIC_CALL,
   FENIX_ERROR_INVALID_POLICY_NAME,
+  FENIX_ERROR_INVALID_POLICY_VALUE,
   FENIX_ERROR_INVALID_TIMESTAMP,
   FENIX_ERROR_INVALID_TIMESTART,
   FENIX_ERROR_INVALID_DEPTH,
@@ -1282,6 +1284,23 @@ int Fenix_Data_group_get_number_of_snapshots(
 int Fenix_Data_group_get_snapshot_at_position(
   int group_id, int position, int* time_stamp
 );
+
+/**
+ * @brief Get the cohort (redundancy partner group) for a data group.
+ *
+ * The cohort is the set of ranks that participate in backing up each other's
+ * data for this group. It includes the calling rank and all partner ranks.
+ * For local-only policies with no redundancy, the cohort contains only the
+ * calling rank.
+ *
+ * The returned group is a duplicate and must be freed by the caller with
+ * MPI_Group_free when no longer needed.
+ *
+ * @param[in] group_id The group to query
+ * @param[out] cohort The cohort group (never MPI_GROUP_NULL)
+ * @returnstatus
+ */
+int Fenix_Data_group_get_cohort(int group_id, MPI_Group* cohort);
 
 //!@unimplemented Get the value of a member's attribute.
 int Fenix_Data_member_attr_get(

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -396,6 +396,9 @@ std::optional<std::vector<int>> group_members(int group_id);
  */
 std::optional<std::vector<int>> group_snapshots(int group_id);
 
+//@!brief Overload of #Fenix_Data_group_get_cohort
+MPI_Group group_cohort(int group_id);
+
 //@!brief Overload of #Fenix_Data_snapshot_delete
 int snapshot_delete(int group_id, int timestamp);
 

--- a/include/fenix/data/component.hpp
+++ b/include/fenix/data/component.hpp
@@ -39,6 +39,9 @@ class DataComponent {
   // Remove a group by id
   void remove_group(int id);
 
+  // Revoke all group cohort communicators
+  void revoke();
+
   // Get number of groups
   size_t count() const { return groups.size(); }
 };

--- a/include/fenix/data/group.hpp
+++ b/include/fenix/data/group.hpp
@@ -77,7 +77,22 @@ namespace fenix::data {
 struct DataGroup {
   DataGroup(int groupid, MPI_Comm c, int timestart, int depth, int policy);
 
-  virtual ~DataGroup() = default;
+  virtual ~DataGroup();
+
+  // Create the cohort group for this policy
+  virtual MPI_Group create_cohort() = 0;
+
+  // Synchronize timestamps across cohort members
+  virtual void sync_timestamps();
+
+  // Initialize group after construction (creates cohort_comm, syncs state)
+  virtual void init() {
+    cohort = create_cohort();
+    MPI_Comm_create_group(comm, cohort, 0, &cohort_comm);
+    MPI_Comm_size(cohort_comm, &cohort_size);
+    MPI_Comm_rank(cohort_comm, &cohort_rank);
+    sync_timestamps();
+  }
 
   int groupid;
   MPI_Comm comm;
@@ -87,11 +102,16 @@ struct DataGroup {
   int timestamp;
   int depth;
   int policy_name;
-  using MemberSet =
-    std::set<std::shared_ptr<DataMember>, DataMemberIdComparator>;
-  MemberSet members;
+
+  std::set<std::shared_ptr<DataMember>, DataMemberIdComparator> members;
   std::vector<int> member_order;
+
   std::set<int, std::greater<int>> timestamps; // Reverse sorted: newest first
+
+  MPI_Group cohort     = MPI_GROUP_NULL;
+  MPI_Comm cohort_comm = MPI_COMM_NULL;
+  int cohort_size      = -1;
+  int cohort_rank      = -1;
 
   std::vector<int> get_member_ids();
   //Search for id, returning null if not found.
@@ -113,11 +133,10 @@ struct DataGroup {
 
   virtual void get_redundant_policy(int* name, void* value) = 0;
 
-  virtual void member_repair(int member_id) = 0;
+  virtual void member_repair(int member_id);
   virtual void member_restore_from_rank(
     int member_id, void* target_bugger, int max, int timestamp, int source_rank
-  )                     = 0;
-  virtual void reinit() = 0;
+  ) = 0;
 
   // Default implementations using timestamps
   virtual void commit();
@@ -125,6 +144,14 @@ struct DataGroup {
   virtual int get_number_of_snapshots();
   virtual int get_snapshot_at_position(int position);
   virtual std::vector<int> get_snapshots();
+
+  // Revoke cohort_comm (called before recovery to invalidate communicator)
+  virtual void revoke();
+
+  MPI_Group get_cohort() const { return cohort; }
+
+  // String representation, for debugging
+  std::string str();
 };
 
 struct DataGroupIdComparator {

--- a/include/fenix/data/member.hpp
+++ b/include/fenix/data/member.hpp
@@ -88,11 +88,11 @@ class DataMember {
   DataMember() = delete;
 
   DataMember(
-    int id, void* data, int count, MPI_Datatype datatype, int depth,
-    std::optional<SerializeFunc> s = {}
+    DataGroup& g, int id, void* data, int count, MPI_Datatype datatype,
+    int depth, std::optional<SerializeFunc> s = {}
   );
   DataMember(
-    int id, void* data, int count, int datatype_size, int depth,
+    DataGroup& g, int id, void* data, int count, int datatype_size, int depth,
     std::optional<SerializeFunc> s = {}
   );
 
@@ -103,20 +103,13 @@ class DataMember {
   int memberid = -1;
   int datatype_size;
   util::DataRef user_data;
+  DataGroup* group;
 
   int elm_count();
 
   // Create a (possibly policy-specific) snapshot with specified capacity
   virtual std::unique_ptr<DataSnapshot> create_snapshot(
     int size, int max_count
-  );
-
-  // Serialize user_data into buf
-  virtual void serialize(const DataSubset& subset, util::DataBuffer& buf);
-
-  // Deserialize buf into dst
-  virtual void deserialize(
-    const DataSubset& subset, util::DataBuffer& buf, const util::DataRef& dst
   );
 
   // Data operations with default local-only implementations
@@ -137,6 +130,7 @@ class DataMember {
   virtual int storev(const DataSubset& subset);
   virtual tasks::Task<int> istore(const DataSubset& subset);
   virtual tasks::Task<int> istorev(const DataSubset& subset);
+  virtual tasks::Task<int> iprotect();
   virtual void repair();
   virtual void commit(int timestamp);
   virtual void snapshot_delete(int timestamp);
@@ -145,6 +139,24 @@ class DataMember {
 
   virtual void attr_set(int attr, void* value);
   virtual void attr_get(int attr, void* value);
+
+  // Returns true if staging snapshot contains unstored data
+  virtual bool has_unstored_data();
+
+  // Essentially an inplace allgather within the cohort - each rank sends the
+  // subset at its cohort rank index.
+  tasks::Task<void> exchange_subsets(std::vector<DataSubset>& subsets);
+
+  // Broadcast subset vector from root to all ranks in cohort
+  tasks::Task<void> broadcast_subsets(
+    const std::vector<DataSubset>& input, std::vector<DataSubset>& output,
+    int root
+  );
+  tasks::Task<void> broadcast_subsets(
+    std::vector<DataSubset>& subsets, int root
+  ) {
+    return broadcast_subsets(subsets, subsets, root);
+  }
 
   virtual ~DataMember() = default;
 
@@ -189,17 +201,18 @@ class DataMember {
     int timestamp, std::source_location loc = std::source_location::current()
   );
 
+  // Remove committed snapshots not in the provided timestamp set
+  // Used by DataGroup::sync_timestamps() to clean up after recovery
+  void cleanup_timestamps(
+    const std::set<int, std::greater<int>>& valid_timestamps
+  );
+
+  friend class DataGroup;
+
  private:
   // Note that Serializers aren't guaranteed to have written their data to the
   // buffer until their destructor is called. So these should usually only be
-  // used to construct temporaries that go to a subset's serialize call
-  Serializer create_serializer(
-    std::optional<SerializeFunc>& sf, const DataSubset& s, util::DataBuffer& b
-  );
-  Serializer create_deserializer(
-    std::optional<SerializeFunc>& sf, const DataSubset& subset,
-    util::DataBuffer& buf, const util::DataRef& dst
-  );
+  // used to construct temporaries that go to a subset's copy_data call
 };
 
 struct DataMemberIdComparator {

--- a/include/fenix/data/policy_imr.hpp
+++ b/include/fenix/data/policy_imr.hpp
@@ -79,81 +79,59 @@ struct IMRSnapshot : public fenix::data::DataSnapshot {
 
   //Accessor for partner snapshot
   DataSnapshot& partner_snapshot() { return partner; }
+
+  // Override to also initialize partner's cohort
+  void init_cohort(MPI_Comm cohort_comm) override;
+  void reinit_cohort(MPI_Comm cohort_comm) override;
 };
 
 struct IMRGroup;
 
-struct IMRMember : public DataMember {
-  IMRMember(DataMember&& member, IMRGroup& group);
+struct BuddyMember : public DataMember {
+  BuddyMember(DataMember&& member, IMRGroup& group);
+  void repair() override;
+  tasks::Task<int> iprotect() override;
 
-  // Override create_snapshot to return IMR IMRSnapshot type
-  std::unique_ptr<DataSnapshot> create_snapshot(
-    int size, int max_count
-  ) override {
-    return std::make_unique<imr::IMRSnapshot>(size, max_count);
+  std::unique_ptr<DataSnapshot> create_snapshot(int size, int count) override {
+    return std::make_unique<imr::IMRSnapshot>(size, count);
   }
-
-  // Staging and loading functions use base class default implementations
-
-  // IMRMember::istore(v) handle local data and region, while istore(v)_impl
-  // handle partner data and region
-  tasks::Task<int> istore(const DataSubset& subset) override;
-  virtual tasks::Task<int> istore_impl(const DataSubset& subset) = 0;
-
-  tasks::Task<int> istorev(const DataSubset& subset) override;
-  virtual tasks::Task<int> istorev_impl(const DataSubset& subset) = 0;
-
-  //Restore all internal snapshot data
-  //Moves snapshots to align with the group's list of timestamps.
-  //Impl must handle actually restoring snapshot data
-  void repair();
-  virtual void repair_impl() = 0;
-
-  IMRGroup& group;
-  int id = memberid;
 
   util::DataBuffer& send_buf;
   util::DataBuffer& recv_buf;
 };
 
-struct BuddyMember : public IMRMember {
-  BuddyMember(DataMember&& member, IMRGroup& group);
-  void repair_impl() override;
-  tasks::Task<int> istore_impl(const DataSubset& subset) override;
-  tasks::Task<int> istorev_impl(const DataSubset& subset) override;
-  tasks::Task<int> exch(
-    const DataSubset& subset, const DataSubset& partner_subset
-  );
-};
-
-struct ParityMember : public IMRMember {
+struct ParityMember : public DataMember {
   ParityMember(DataMember&& member, IMRGroup& group);
-  void repair_impl() override;
-  tasks::Task<int> istore_impl(const DataSubset& subset) override;
+  void repair() override;
+  tasks::Task<int> iprotect() override;
 
-  tasks::Task<int> istorev_impl(const DataSubset& subset) override {
-    fatal_print("IMR mode 5 cannot storev");
-    co_return 0;
+  // Ensures snapshot sized appropriately.
+  // Returns vector of parity bytes for each cohort member, including self.
+  std::vector<int> prepare_for_parity(IMRSnapshot& snap);
+
+  std::unique_ptr<DataSnapshot> create_snapshot(int size, int count) override {
+    return std::make_unique<imr::IMRSnapshot>(size, count);
   }
+
+  util::DataBuffer& send_buf;
+  util::DataBuffer& recv_buf;
 };
 
 struct IMRGroup : public DataGroup {
   IMRGroup(int id, MPI_Comm comm, int timestart, int depth, int* policy);
 
+  // Helpers to extract mode and rank_separation from policy_vals
+  static int get_mode(int* policy_vals);
+  static int get_rank_sep(int* policy_vals, MPI_Comm comm);
+
+  MPI_Group create_cohort() override;
+  void init() override;
+
   int mode;
   int rank_separation;
-  std::vector<int> partners;
-
-  MPI_Comm set_comm = MPI_COMM_NULL;
-  int set_size, set_rank;
-  static inline bool set_comm_revoke_callback = false;
+  int set_size_policy; // For mode 5, the set_size from policy_vals
 
   util::DataBuffer send_buf, recv_buf;
-
-  void sync_timestamps();
-  void build_set_comm();
-
-  std::string str();
 
   void emplace_member(DataMember&& member) override;
   void get_redundant_policy(int* name, void* value) override;
@@ -164,8 +142,6 @@ struct IMRGroup : public DataGroup {
   void member_restore_from_rank(
     int member_id, void* buffer, int max, int timestamp, int source_rank
   ) override;
-
-  void reinit() override;
 };
 
 } // namespace fenix::data::imr

--- a/include/fenix/data/policy_local.hpp
+++ b/include/fenix/data/policy_local.hpp
@@ -16,13 +16,20 @@ struct LocalGroup : public DataGroup {
   LocalGroup(int id, MPI_Comm c, int ts, int depth)
     : DataGroup(id, c, ts, depth, FENIX_DATA_POLICY_LOCAL) {}
 
+  MPI_Group create_cohort() override {
+    MPI_Group comm_group;
+    MPI_Comm_group(comm, &comm_group);
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Group cohort_group;
+    MPI_Group_incl(comm_group, 1, &rank, &cohort_group);
+    MPI_Group_free(&comm_group);
+    return cohort_group;
+  }
+
   void get_redundant_policy(int* name, void* value) override {
     *name = FENIX_DATA_POLICY_LOCAL;
   }
-
-  // Local policy has no reliability, there is no repair or reinit to do
-  void reinit() override {};
-  void member_repair(int member_id) override {}
 
   void member_restore_from_rank(
     int member_id, void* buffer, int max, int timestamp, int source_rank

--- a/include/fenix/data/snapshot.hpp
+++ b/include/fenix/data/snapshot.hpp
@@ -1,7 +1,11 @@
 #ifndef __FENIX_DATA_SNAPSHOT_HPP__
 #define __FENIX_DATA_SNAPSHOT_HPP__
 
+#include <mpi.h>
+#include <optional>
 #include "fenix/data/util/buffer.hpp"
+#include "fenix/data/util/data_ref.hpp"
+#include "fenix/data/util/serializer.hpp"
 #include "fenix/data/subset.hpp"
 
 namespace fenix::data {
@@ -13,24 +17,53 @@ namespace fenix::data {
 class DataSnapshot {
  protected:
   util::DataBuffer buf_; ///< Primary checkpoint data buffer
-  DataSubset region_;    ///< Data region captured in this snapshot
   int timestamp_;        ///< Snapshot version/commit timestamp
   int elm_size_;         ///< Size of each element in bytes
   int elm_max_count_;    ///< Maximum number of elements
 
+  MPI_Group cohort_ = MPI_GROUP_NULL;
+
  public:
+  int cohort_rank = -1; ///< This rank's index within the cohort
+
+  std::vector<DataSubset> protected_subsets; ///< Subsets protected by each
+                                             ///< cohort member (including self)
+  std::vector<DataSubset>
+    staged_subsets; ///< Subsets staged by each cohort member (including self)
+
   DataSnapshot(int elm_size, int max_count);
   virtual ~DataSnapshot() = default;
 
   DataSnapshot(DataSnapshot&&)            = default;
   DataSnapshot& operator=(DataSnapshot&&) = default;
 
-  // DataSnapshots are  move-only
+  // DataSnapshots are move-only
   DataSnapshot(const DataSnapshot&)            = delete;
   DataSnapshot& operator=(const DataSnapshot&) = delete;
 
-  // Clear the buffer and region, reset timestamp to -2.
+  // Clear the buffer and region, reset timestamp to -2, cohort to
+  // MPI_GROUP_NULL.
   void reset();
+
+  // Called when snapshot is first staged to - sets cohort and allocates
+  // storage for tracking subsets per cohort partner
+  virtual void init_cohort(MPI_Comm cohort_comm);
+
+  // Called during repair - replaces cohort if already initialized, or
+  // initializes if not
+  virtual void reinit_cohort(MPI_Comm cohort_comm);
+
+  // Create a serializer that writes to this snapshot's buffer from the source
+  util::Serializer create_serializer(
+    const util::DataRef& source, std::optional<SerializeFunc>& sf,
+    const DataSubset& subset
+  );
+
+  // Create a deserializer that reads from this snapshot's buffer to destination
+  util::Serializer create_deserializer(
+    const util::DataRef& dst, std::optional<SerializeFunc>& sf,
+    const DataSubset& subset
+  );
 
   char* data() { return buf_.data(); }
   int size() const { return buf_.size(); }
@@ -44,12 +77,20 @@ class DataSnapshot {
   int timestamp() const { return timestamp_; }
   void set_timestamp(int ts) { timestamp_ = ts; }
 
-  const DataSubset& region() const { return region_; }
-  DataSubset& region() { return region_; }
+  const DataSubset& staged_subset() const {
+    return staged_subsets[cohort_rank];
+  }
+  DataSubset& staged_subset() { return staged_subsets[cohort_rank]; }
+
+  const DataSubset& protected_subset() const {
+    return protected_subsets[cohort_rank];
+  }
+  DataSubset& protected_subset() { return protected_subsets[cohort_rank]; }
 
   util::DataBuffer& buf() { return buf_; }
 
   int elm_size() const { return elm_size_; }
+  void set_elm_size(int size) { elm_size_ = size; }
   int elm_max_count() const { return elm_max_count_; }
 };
 

--- a/include/fenix/data/subset.hpp
+++ b/include/fenix/data/subset.hpp
@@ -77,11 +77,11 @@ struct DataRegion {
 
   DataRegion(std::pair<size_t, size_t> b) : DataRegion(b, 0, MAX) {};
   DataRegion(std::pair<size_t, size_t> b, size_t m_reps, size_t m_stride)
-    : start(b.first),
-      end(
-        (b.second != MAX && b.second + 1 == b.first + m_stride)
-          ? b.second + m_reps * m_stride : b.second
-      ),
+    : start(b.first), end(
+                        (b.second != MAX && b.second + 1 == b.first + m_stride)
+                          ? b.second + m_reps * m_stride
+                          : b.second
+                      ),
       reps(
         (b.second == MAX || b.second + 1 == b.first + m_stride) ? 0 : m_reps
       ),

--- a/include/fenix/tasks/mpi.hpp
+++ b/include/fenix/tasks/mpi.hpp
@@ -129,6 +129,18 @@ auto allreduce(const std::vector<T, A>& sv, T& rb, MPI_Op o, MPI_Comm c) {
   return allreduce(&sv[0], rb, sv.size(), o, c);
 }
 
+// Template for pointer types - pass pointer directly to MPI
+template <typename T>
+MPITask reduce(
+  const void* sb, T* rb, int n, MPI_Datatype d, MPI_Op o, int r, MPI_Comm c
+) {
+  MPI_Request request;
+  Status ret = MPI_Ireduce(sb, rb, n, d, o, r, c, &request);
+  if (ret) ret = co_await request;
+  co_return ret;
+}
+
+// Template for reference types - take address of reference
 template <typename T>
 MPITask reduce(
   const void* sb, T& rb, int n, MPI_Datatype d, MPI_Op o, int r, MPI_Comm c
@@ -169,6 +181,44 @@ auto bcast(T& b, int r, MPI_Comm c) {
 template <typename T, typename A>
 auto bcast(std::vector<T, A>& v, int r, MPI_Comm c) {
   return bcast(&v[0], v.size(), r, c);
+}
+
+template <typename ST, typename RT>
+MPITask allgather(
+  const ST* sb, int sn, MPI_Datatype sd, RT* rb, int rn, MPI_Datatype rd,
+  MPI_Comm c
+) {
+  MPI_Request request;
+  Status ret = MPI_Iallgather(sb, sn, sd, rb, rn, rd, c, &request);
+  if (ret) ret = co_await request;
+  co_return ret;
+}
+template <typename ST, typename RT>
+auto allgather(const ST* sb, int sn, RT* rb, int rn, MPI_Comm c) {
+  return allgather(
+    sb, util::count(sb, sn), util::datatype(sb), rb, util::count(rb, rn),
+    util::datatype(rb), c
+  );
+}
+
+template <typename ST, typename RT>
+MPITask allgatherv(
+  const ST* sb, int sn, MPI_Datatype sd, RT* rb, const int* rn,
+  const int* displs, MPI_Datatype rd, MPI_Comm c
+) {
+  MPI_Request request;
+  Status ret = MPI_Iallgatherv(sb, sn, sd, rb, rn, displs, rd, c, &request);
+  if (ret) ret = co_await request;
+  co_return ret;
+}
+template <typename ST, typename RT>
+auto allgatherv(
+  const ST* sb, int sn, RT* rb, const int* rn, const int* displs, MPI_Comm c
+) {
+  return allgatherv(
+    sb, util::count(sb, sn), util::datatype(sb), rb, rn, displs,
+    util::datatype(rb), c
+  );
 }
 
 inline MPITask probe(int src, int tag, MPI_Comm comm) {

--- a/include/fenix/tasks/task.hpp
+++ b/include/fenix/tasks/task.hpp
@@ -13,7 +13,7 @@ namespace fenix::tasks {
 // WARNING: eager tasks can cause gross double free errors, due to some
 // early wonkiness in the C++ spec and in compiler implementations
 template <typename T, bool eager /*= false*/>
-class Task {
+class [[nodiscard("Must wait/await tasks")]] Task {
  public:
   using PromiseT     = Promise<T, eager>;
   using TaskT        = Task<T, eager>;
@@ -55,7 +55,9 @@ class Task {
 
   auto result() {
     this->wait();
-    return promise().result();
+    if constexpr (!std::is_same_v<T, void>) {
+      return promise().result();
+    }
   }
 
  private:

--- a/include/fenix_exception.hpp
+++ b/include/fenix_exception.hpp
@@ -118,6 +118,10 @@ struct RuntimeException : public std::exception {
   const std::string_view error_string;
   const std::source_location location;
 
+  // Allow direct comparison with error codes
+  bool operator==(int error_code) const noexcept { return error == error_code; }
+  bool operator!=(int error_code) const noexcept { return error != error_code; }
+
  private:
   mutable std::string m_string;
 };

--- a/src/data/component.cpp
+++ b/src/data/component.cpp
@@ -63,13 +63,16 @@ void DataComponent::group_create(
     // Add to component
     groups.insert(std::shared_ptr<DataGroup>(new_group));
     group_order.push_back(groupid);
+
+    // Initialize the group (creates cohort, cohort_comm, syncs state)
+    new_group->init();
   } else {
     // Already created. Renew the MPI communicator
     group->comm = comm;
     MPI_Comm_rank(comm, &(group->current_rank));
 
     // Reinit group metadata as needed w/ new communicator
-    group->reinit();
+    group->init();
   }
 }
 
@@ -96,6 +99,12 @@ DataMember* DataComponent::find_member(
   int groupid, int memberid, std::source_location loc
 ) {
   return this->find_group(groupid, loc)->find_member(memberid, loc);
+}
+
+void DataComponent::revoke() {
+  for (auto& group : groups) {
+    group->revoke();
+  }
 }
 
 } // namespace fenix::data

--- a/src/data/group.cpp
+++ b/src/data/group.cpp
@@ -56,8 +56,12 @@
 
 #include <cassert>
 #include <algorithm>
+#include <sstream>
 
 #include "mpi.h"
+#ifndef MPICH_VERSION
+#include <mpi-ext.h>
+#endif
 #include "fenix-config.h"
 #include "fenix_ext.hpp"
 #include "fenix_util.hpp"
@@ -78,6 +82,15 @@ DataGroup::DataGroup(
   timestamp    = -1;
   depth        = m_depth;
   policy_name  = m_policy;
+}
+
+DataGroup::~DataGroup() {
+  if (cohort != MPI_GROUP_NULL) {
+    MPI_Group_free(&cohort);
+  }
+  if (cohort_comm != MPI_COMM_NULL) {
+    MPI_Comm_free(&cohort_comm);
+  }
 }
 
 DataMember* DataGroup::search_member(int id) {
@@ -102,7 +115,7 @@ void DataGroup::member_create(
   if (members.find(id) != members.end()) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
 
   // Let policy replace with its specific Member type
-  this->emplace_member({id, data, count, datatype, depth});
+  this->emplace_member({*this, id, data, count, datatype, depth});
 
   auto iter = members.find(id);
   fenix_assert(iter != members.end(), "emplace_member failed");
@@ -117,7 +130,7 @@ void DataGroup::member_create(
 ) {
   if (members.find(id) != members.end()) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
 
-  this->emplace_member({id, data, count, datatype, depth, s});
+  this->emplace_member({*this, id, data, count, datatype, depth, s});
 
   auto iter = members.find(id);
   fenix_assert(iter != members.end(), "emplace_member failed");
@@ -133,7 +146,7 @@ void DataGroup::member_create(
   if (members.find(id) != members.end()) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
 
   // Let policy replace with its specific Member type
-  this->emplace_member({id, data, count, datatype_size, depth});
+  this->emplace_member({*this, id, data, count, datatype_size, depth});
 
   auto iter = members.find(id);
   fenix_assert(iter != members.end(), "emplace_member failed");
@@ -161,6 +174,13 @@ void DataGroup::member_delete(int id) {
 std::vector<int> DataGroup::get_member_ids() { return member_order; }
 
 void DataGroup::commit() {
+  // Check that all members have stored their data
+  for (auto& member : members) {
+    if (member->has_unstored_data()) {
+      FENIX_THROW(FENIX_ERROR_MEMBER_UNSTORED);
+    }
+  }
+
   if (timestamps.size() == depth + 1) {
     // Remove oldest timestamp (last in reverse-sorted set)
     timestamps.erase(--timestamps.end());
@@ -197,6 +217,131 @@ int DataGroup::get_snapshot_at_position(int position) {
 
 std::vector<int> DataGroup::get_snapshots() {
   return {timestamps.begin(), timestamps.end()};
+}
+
+void DataGroup::revoke() {
+  if (cohort_comm != MPI_COMM_NULL) {
+    MPIX_Comm_revoke(cohort_comm);
+    cohort_comm = MPI_COMM_NULL;
+  }
+}
+
+std::string DataGroup::str() {
+  // Extract partners from cohort group
+  int cohort_size;
+  MPI_Group_size(cohort, &cohort_size);
+
+  std::vector<int> cohort_ranks(cohort_size);
+  for (int i = 0; i < cohort_size; i++) cohort_ranks[i] = i;
+
+  std::vector<int> partners(cohort_size);
+  MPI_Group comm_group;
+  MPI_Comm_group(comm, &comm_group);
+  MPI_Group_translate_ranks(
+    cohort, cohort_size, cohort_ranks.data(), comm_group, partners.data()
+  );
+  MPI_Group_free(&comm_group);
+
+  std::stringstream ss;
+  ss << "Group " << groupid << " set ";
+  ss << "[" << partners[0];
+  for (int i = 1; i < partners.size(); i++) ss << ", " << partners[i];
+  ss << "]";
+  return ss.str();
+}
+
+void DataGroup::sync_timestamps() {
+  fenix_assert(
+    cohort_comm != MPI_COMM_NULL, "sync_timestamps called with NULL cohort_comm"
+  );
+
+  int n_snapshots = timestamps.size();
+  MPI_Allreduce(MPI_IN_PLACE, &n_snapshots, 1, MPI_INT, MPI_MAX, cohort_comm);
+
+  // Create vector with current timestamps, pad with -1 if needed
+  std::vector<int> ts(timestamps.begin(), timestamps.end());
+  ts.resize(n_snapshots, -1);
+
+  MPI_Allreduce(
+    MPI_IN_PLACE, ts.data(), n_snapshots, MPI_INT, MPI_MAX, cohort_comm
+  );
+
+  // Rebuild set from vector (automatically reverse sorted)
+  timestamps.clear();
+  for (int t : ts) {
+    timestamps.insert(t);
+  }
+
+  if (!timestamps.empty()) timestamp = *timestamps.begin(); // Newest first
+  else timestamp = -1;
+
+  // Remove committed snapshots from members that are not in synced timestamps
+  for (auto& member : members) {
+    member->cleanup_timestamps(timestamps);
+  }
+}
+
+void DataGroup::member_repair(int member_id) {
+  fenix_assert(
+    cohort_comm != MPI_COMM_NULL, "member_repair called with NULL cohort_comm"
+  );
+
+  DataMember* member = search_member(member_id);
+
+  // Query cohort size and rank
+  int cohort_size, cohort_rank;
+  MPI_Comm_size(cohort_comm, &cohort_size);
+  MPI_Comm_rank(cohort_comm, &cohort_rank);
+
+  // Gather which cohort members have this member
+  std::vector<int> found_members(cohort_size);
+  found_members[cohort_rank] = member ? 1 : 0;
+
+  MPI_Allgather(
+    MPI_IN_PLACE, 1, MPI_INT, found_members.data(), 1, MPI_INT, cohort_comm
+  );
+
+  // Count missing and find first rank that has it
+  int n_missing   = 0;
+  int first_found = -1;
+  for (int i = 0; i < cohort_size; i++) {
+    if (!found_members[i]) {
+      n_missing++;
+    }
+    if (found_members[i] && first_found == -1) {
+      first_found = i;
+    }
+  }
+
+  // Only throw if NO cohort member knows about this member
+  if (n_missing == cohort_size) {
+    if (cohort_rank == 0) {
+      debug_print(
+        "ERROR Group %d member_id %d not found in any cohort member\n", groupid,
+        member_id
+      );
+    }
+    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  }
+
+  // If any rank is missing the member, broadcast the packet
+  if (n_missing > 0) {
+    DataMemberPacket packet;
+    if (cohort_rank == first_found) packet = member->to_packet();
+
+    MPI_Bcast(&packet, sizeof(packet), MPI_BYTE, first_found, cohort_comm);
+
+    // If I'm missing it, create it now
+    if (!found_members[cohort_rank]) {
+      member_create(
+        packet.memberid, nullptr, packet.current_count, packet.datatype_size
+      );
+      member = find_member(member_id);
+    }
+  }
+
+  // Let the member handle policy-specific repair
+  member->repair();
 }
 
 } //end namespace fenix::data

--- a/src/data/member.cpp
+++ b/src/data/member.cpp
@@ -57,6 +57,8 @@
 #include "fenix_util.hpp"
 #include "fenix/data/group.hpp"
 #include "fenix/data/member.hpp"
+#include "fenix/tasks/mpi.hpp"
+#include <cstring>
 
 namespace fenix::data {
 
@@ -73,16 +75,16 @@ DataMemberPacket DataMember::to_packet() {
 }
 
 DataMember::DataMember(
-  int id, void* d, int c, MPI_Datatype dt, int depth,
+  DataGroup& g, int id, void* d, int c, MPI_Datatype dt, int depth,
   std::optional<SerializeFunc> s
 )
-  : DataMember(id, d, c, __fenix_get_size(dt), depth, s) {}
+  : DataMember(g, id, d, c, __fenix_get_size(dt), depth, s) {}
 
 DataMember::DataMember(
-  int id, void* data, int count, int dsize, int depth,
+  DataGroup& g, int id, void* data, int count, int dsize, int depth,
   std::optional<SerializeFunc> s
 )
-  : memberid(id), datatype_size(dsize), depth_(depth) {
+  : memberid(id), datatype_size(dsize), depth_(depth), group(&g) {
   if (count == FENIX_RESIZEABLE) user_data = DataRef((char*)data);
   else user_data = DataRef((char*)data, count * dsize);
 
@@ -95,6 +97,12 @@ DataMember::DataMember(
 
 void DataMember::init_snapshots() {
   stage_snapshot_ = this->create_snapshot(datatype_size, elm_count());
+
+  // Initialize cohort on the staging snapshot
+  if (group && group->cohort_comm != MPI_COMM_NULL) {
+    stage_snapshot_->init_cohort(group->cohort_comm);
+  }
+
   for (int i = 0; i < depth_ + 1; i++) {
     avail_snapshots_.push_back(
       this->create_snapshot(datatype_size, elm_count())
@@ -123,6 +131,9 @@ DataMember::DataMember(DataMember&& o) {
   avail_snapshots_  = std::move(o.avail_snapshots_);
   depth_            = o.depth_;
   o.depth_          = 0;
+
+  group   = o.group;
+  o.group = nullptr;
 }
 
 int DataMember::elm_count() {
@@ -132,56 +143,11 @@ int DataMember::elm_count() {
   return user_data.size() / datatype_size;
 }
 
-void DataMember::serialize(const DataSubset& subset, DataBuffer& buf) {
-  subset.copy_data(create_serializer(ser_func, subset, buf));
-}
-
-void DataMember::deserialize(
-  const DataSubset& subset, DataBuffer& buf, const DataRef& dst
-) {
-  subset.copy_data(create_deserializer(ser_func, subset, buf, dst));
-}
-
-fenix::data::util::Serializer DataMember::create_serializer(
-  std::optional<SerializeFunc>& sf, const DataSubset& subset, DataBuffer& buf
-) {
-  if (open_serializer) {
-    if (open_serializer->get_dir() == FENIX_SERIALIZE)
-      FENIX_THROW(FENIX_ERROR_MEMBER_STAGING);
-    FENIX_THROW(FENIX_ERROR_MEMBER_LOADING);
-  }
-
-  DataRef output = user_data;
-  if (subset.is_bounded()) {
-    output = output.bounded(subset.max_count() * datatype_size);
-  }
-
-  if (output.is_bounded()) {
-    if (buf.size() < output.size()) buf.resize(output.size());
-  } else if (!sf) {
-    FENIX_THROW(FENIX_ERROR_INVALID_SUBSET);
-  }
-
-  return Serializer(buf, sf, output, FENIX_SERIALIZE, datatype_size);
-}
-
-fenix::data::util::Serializer DataMember::create_deserializer(
-  std::optional<SerializeFunc>& sf, const DataSubset& subset, DataBuffer& buf,
-  const DataRef& dst
-) {
-  if (open_serializer) {
-    if (open_serializer->get_dir() == FENIX_SERIALIZE)
-      FENIX_THROW(FENIX_ERROR_MEMBER_STAGING);
-    FENIX_THROW(FENIX_ERROR_MEMBER_LOADING);
-  }
-  return Serializer(buf, sf, dst, FENIX_DESERIALIZE, datatype_size);
-}
-
 void DataMember::stage(const DataSubset& subset) {
   if (subset == SUBSET_PRESTAGED) FENIX_THROW("Cannot stage SUBSET_PRESTAGED");
 
   DataSnapshot& snap = *stage_snapshot_;
-  this->serialize(subset, snap.buf());
+  subset.copy_data(snap.create_serializer(user_data, ser_func, subset));
 
   fenix_assert(snap.buf().size() % datatype_size == 0);
   fenix_assert(snap.buf().size() <= user_data.size());
@@ -210,17 +176,19 @@ void DataMember::stage_inplace(void* buf, const DataSubset& subset) {
 
 void DataMember::stage_begin(FILE** fp) {
   std::optional<SerializeFunc> sf = SerializeFileFunc{};
-  DataBuffer& buf                 = stage_snapshot_->buf();
-  buf.resize(0);
-  open_serializer.emplace(create_serializer(sf, SUBSET_FULL, buf));
+  stage_snapshot_->buf().resize(0);
+  open_serializer.emplace(
+    stage_snapshot_->create_serializer(user_data, sf, SUBSET_FULL)
+  );
   *fp = open_serializer->get_file();
 }
 
 void DataMember::stage_begin(std::iostream** strm) {
   std::optional<SerializeFunc> sf = SerializeStreamFunc{};
-  DataBuffer& buf                 = stage_snapshot_->buf();
-  buf.resize(0);
-  open_serializer.emplace(create_serializer(sf, SUBSET_FULL, buf));
+  stage_snapshot_->buf().resize(0);
+  open_serializer.emplace(
+    stage_snapshot_->create_serializer(user_data, sf, SUBSET_FULL)
+  );
   *strm = open_serializer->get_stream();
 }
 
@@ -237,11 +205,10 @@ void DataMember::stage_end() {
 
 void DataMember::load_begin(FILE** fp, int timestamp, DataSubset& subset) {
   DataSnapshot* snap = find_snapshot(timestamp);
-  subset             = snap->region();
+  subset             = snap->protected_subset();
 
   std::optional<SerializeFunc> sf = SerializeFileFunc{};
-  DataBuffer& buf                 = snap->buf();
-  open_serializer.emplace(create_deserializer(sf, SUBSET_FULL, buf, nullptr));
+  open_serializer.emplace(snap->create_deserializer(nullptr, sf, SUBSET_FULL));
   *fp = open_serializer->get_file();
 }
 
@@ -249,11 +216,10 @@ void DataMember::load_begin(
   std::iostream** strm, int timestamp, DataSubset& subset
 ) {
   DataSnapshot* snap = find_snapshot(timestamp);
-  subset             = snap->region();
+  subset             = snap->protected_subset();
 
   std::optional<SerializeFunc> sf = SerializeStreamFunc{};
-  DataBuffer& buf                 = snap->buf();
-  open_serializer.emplace(create_deserializer(sf, SUBSET_FULL, buf, nullptr));
+  open_serializer.emplace(snap->create_deserializer(nullptr, sf, SUBSET_FULL));
   *strm = open_serializer->get_stream();
 }
 
@@ -274,8 +240,10 @@ void DataMember::load(
 
   if (timestamp != FENIX_DATA_SNAPSHOT_ALL) {
     DataSnapshot& snap = *find_snapshot(timestamp);
-    data_found         = snap.region();
-    if (target_count > 0) deserialize(data_found, snap.buf(), dst);
+    data_found         = snap.protected_subset();
+    if (target_count > 0) {
+      data_found.copy_data(snap.create_deserializer(dst, ser_func, data_found));
+    }
   } else {
     if (commit_snapshots_.empty()) FENIX_THROW(FENIX_ERROR_NODATA_FOUND);
 
@@ -285,9 +253,10 @@ void DataMember::load(
       DataSnapshot& snap = **it;
       fenix_assert(snap.timestamp() >= 0);
       if (target_count > 0) {
-        this->deserialize(snap.region() - data_found, snap.buf(), dst);
+        DataSubset partial = snap.protected_subset() - data_found;
+        partial.copy_data(snap.create_deserializer(dst, ser_func, partial));
       }
-      data_found += snap.region();
+      data_found += snap.protected_subset();
       if (target_count > 0 && data_found.includes_all(target_count - 1)) break;
     }
   }
@@ -311,14 +280,28 @@ int DataMember::storev(const DataSubset& subset) {
 }
 
 tasks::Task<int> DataMember::istore(const DataSubset& subset) {
-  // Default: No data resilience
   if (subset != SUBSET_PRESTAGED) this->stage(subset);
-  co_return FENIX_SUCCESS;
+  for (int i = 0; i < stage_snapshot_->staged_subsets.size(); i++) {
+    if (i == stage_snapshot_->cohort_rank) continue;
+    stage_snapshot_->staged_subsets[i] = stage_snapshot_->staged_subset();
+  }
+  return iprotect();
 }
 
 tasks::Task<int> DataMember::istorev(const DataSubset& subset) {
   // Default: No data resilience
   if (subset != SUBSET_PRESTAGED) this->stage(subset);
+  co_await exchange_subsets(stage_snapshot_->staged_subsets);
+  co_return co_await iprotect();
+}
+
+tasks::Task<int> DataMember::iprotect() {
+  // Default: simply move staged data to protected (no remote redundancy)
+  DataSnapshot& snap = *stage_snapshot_;
+  for (int i = 0; i < snap.protected_subsets.size(); i++) {
+    snap.protected_subsets[i] += snap.staged_subsets[i];
+    snap.staged_subsets[i] = {};
+  }
   co_return FENIX_SUCCESS;
 }
 
@@ -328,6 +311,8 @@ void DataMember::repair() {
 }
 
 void DataMember::commit(int timestamp) {
+  fenix_assert(stage_snapshot_->staged_subset() == SUBSET_EMPTY);
+
   // Set timestamp on staging snapshot
   stage_snapshot_->set_timestamp(timestamp);
 
@@ -346,6 +331,9 @@ void DataMember::commit(int timestamp) {
   } else {
     stage_snapshot_ = this->create_snapshot(datatype_size, elm_count());
   }
+
+  // Initialize cohort for the new stage snapshot
+  stage_snapshot_->init_cohort(group->cohort_comm);
 }
 
 void DataMember::snapshot_delete(int timestamp) {
@@ -368,6 +356,125 @@ std::unique_ptr<DataSnapshot> DataMember::create_snapshot(
   // Default implementation creates a base DataSnapshot
   // Derived classes override to create policy-specific Entry types
   return std::make_unique<DataSnapshot>(size, max_count);
+}
+
+tasks::Task<void> DataMember::exchange_subsets(
+  std::vector<DataSubset>& subsets
+) {
+  int cohort_size, cohort_rank;
+  MPI_Comm_size(group->cohort_comm, &cohort_size);
+  MPI_Comm_rank(group->cohort_comm, &cohort_rank);
+
+  fenix_assert(subsets.size() == cohort_size);
+
+  // Serialize this rank's subset (at index cohort_rank)
+  DataBuffer send_buf;
+  subsets[cohort_rank].serialize(send_buf);
+
+  // Gather sizes from all cohort members
+  int local_size = send_buf.size();
+  std::vector<int> all_sizes(cohort_size);
+  co_await tasks::mpi::allgather(
+    &local_size, 1, MPI_INT, all_sizes.data(), 1, MPI_INT, group->cohort_comm
+  );
+
+  // Prepare receive buffer and displacements for allgatherv
+  std::vector<int> displs(cohort_size);
+  int total_size = 0;
+  for (int i = 0; i < cohort_size; i++) {
+    displs[i] = total_size;
+    total_size += all_sizes[i];
+  }
+  DataBuffer recv_buf;
+  recv_buf.resize(total_size);
+
+  // Gather all subsets - each rank contributes its own index
+  co_await tasks::mpi::allgatherv(
+    send_buf.data(), local_size, MPI_BYTE, recv_buf.data(), all_sizes.data(),
+    displs.data(), MPI_BYTE, group->cohort_comm
+  );
+
+  // Deserialize all received subsets back into the vector
+  for (int i = 0; i < cohort_size; i++) {
+    DataBuffer rank_buf;
+    rank_buf.resize(all_sizes[i]);
+    std::memcpy(rank_buf.data(), recv_buf.data() + displs[i], all_sizes[i]);
+    subsets[i] = DataSubset(rank_buf);
+  }
+
+  co_return;
+}
+
+tasks::Task<void> DataMember::broadcast_subsets(
+  const std::vector<DataSubset>& input, std::vector<DataSubset>& output,
+  int root
+) {
+  int cohort_size, cohort_rank;
+  MPI_Comm_size(group->cohort_comm, &cohort_size);
+  MPI_Comm_rank(group->cohort_comm, &cohort_rank);
+
+  // Prepare buffer on root
+  DataBuffer send_buf;
+  int total_size = 0;
+
+  if (cohort_rank == root) {
+    // First pack the number of subsets
+    int num_subsets = input.size();
+    send_buf.resize(sizeof(int));
+    std::memcpy(send_buf.data(), &num_subsets, sizeof(int));
+    total_size = sizeof(int);
+
+    // Then pack each subset: size + data
+    for (const auto& subset : input) {
+      DataBuffer subset_buf;
+      subset.serialize(subset_buf);
+      int subset_size = subset_buf.size();
+
+      // Resize and pack size
+      send_buf.resize(total_size + sizeof(int) + subset_size);
+      std::memcpy(send_buf.data() + total_size, &subset_size, sizeof(int));
+      total_size += sizeof(int);
+
+      // Pack data
+      std::memcpy(send_buf.data() + total_size, subset_buf.data(), subset_size);
+      total_size += subset_size;
+    }
+  }
+
+  // Broadcast total size
+  co_await tasks::mpi::bcast(&total_size, 1, MPI_INT, root, group->cohort_comm);
+
+  // Allocate buffer on non-root
+  if (cohort_rank != root) {
+    send_buf.resize(total_size);
+  }
+
+  // Broadcast data
+  co_await tasks::mpi::bcast(
+    send_buf.data(), total_size, MPI_BYTE, root, group->cohort_comm
+  );
+
+  // Unpack on all ranks (handles input == output case correctly)
+  int offset = 0;
+  int num_subsets;
+  std::memcpy(&num_subsets, send_buf.data() + offset, sizeof(int));
+  offset += sizeof(int);
+
+  output.resize(num_subsets);
+  for (int i = 0; i < num_subsets; i++) {
+    int subset_size;
+    std::memcpy(&subset_size, send_buf.data() + offset, sizeof(int));
+    offset += sizeof(int);
+
+    DataBuffer subset_buf;
+    subset_buf.resize(subset_size);
+    std::memcpy(subset_buf.data(), send_buf.data() + offset, subset_size);
+    offset += subset_size;
+
+    output[i] = DataSubset(subset_buf);
+  }
+
+  co_return;
 }
 
 DataSnapshot& DataMember::current_snapshot() {
@@ -405,7 +512,8 @@ void DataMember::attr_set(int attr, void* value) {
     int new_count = *((int*)value);
     if (new_count != elm_count() &&
         (!commit_snapshots_.empty() ||
-         stage_snapshot_->region() != SUBSET_EMPTY)) {
+         stage_snapshot_->staged_subset() != SUBSET_EMPTY ||
+         stage_snapshot_->protected_subset() != SUBSET_EMPTY)) {
       FENIX_THROW(FENIX_ERROR_INVALID_LOGIC_CALL);
     }
     if (new_count == FENIX_RESIZEABLE) {
@@ -423,7 +531,8 @@ void DataMember::attr_set(int attr, void* value) {
 
     if (dtype_size != datatype_size &&
         (!commit_snapshots_.empty() ||
-         stage_snapshot_->region() != SUBSET_EMPTY)) {
+         stage_snapshot_->staged_subset() != SUBSET_EMPTY ||
+         stage_snapshot_->protected_subset() != SUBSET_EMPTY)) {
       FENIX_THROW(FENIX_ERROR_INVALID_LOGIC_CALL);
     }
 
@@ -434,6 +543,15 @@ void DataMember::attr_set(int attr, void* value) {
       size_t new_size = old_count * dtype_size;
       user_data       = {user_data.data(), new_size};
     }
+
+    // Update stage_snapshot_ element size to match new datatype
+    stage_snapshot_->set_elm_size(dtype_size);
+
+    // Update available snapshots element size as well
+    for (auto& snap : avail_snapshots_) {
+      snap->set_elm_size(dtype_size);
+    }
+
     break;
   }
   default:
@@ -460,4 +578,28 @@ void DataMember::attr_get(int attr, void* value) {
     FENIX_THROW(FENIX_ERROR_INVALID_ATTRIBUTE_NAME);
   }
 }
+
+bool DataMember::has_unstored_data() {
+  return stage_snapshot_ && stage_snapshot_->staged_subset() != SUBSET_EMPTY;
+}
+
+void DataMember::cleanup_timestamps(
+  const std::set<int, std::greater<int>>& valid_timestamps
+) {
+  for (auto it = commit_snapshots_.begin(); it != commit_snapshots_.end();) {
+    int snap_ts = (*it)->timestamp();
+    auto found  = valid_timestamps.find(snap_ts);
+    if (found != valid_timestamps.end()) {
+      ++it;
+      continue;
+    }
+
+    // Not in valid timestamps, extract and move to available pool
+    std::unique_ptr<DataSnapshot> snap =
+      std::move(commit_snapshots_.extract(it++).value());
+    snap->reset();
+    avail_snapshots_.push_back(std::move(snap));
+  }
+}
+
 } //namespace fenix::data

--- a/src/data/policy_imr.cpp
+++ b/src/data/policy_imr.cpp
@@ -87,6 +87,16 @@ using util::DataBuffer;
 IMRSnapshot::IMRSnapshot(int size, int max_count)
   : DataSnapshot(size, max_count), partner(size, max_count) {}
 
+void IMRSnapshot::init_cohort(MPI_Comm cohort_comm) {
+  DataSnapshot::init_cohort(cohort_comm);
+  partner.init_cohort(cohort_comm);
+}
+
+void IMRSnapshot::reinit_cohort(MPI_Comm cohort_comm) {
+  DataSnapshot::reinit_cohort(cohort_comm);
+  partner.reinit_cohort(cohort_comm);
+}
+
 // Helper to access IMR Entry from base DataSnapshot
 static IMRSnapshot& get_entry(DataSnapshot& snap) {
   return *static_cast<IMRSnapshot*>(&snap);
@@ -96,12 +106,9 @@ static IMRSnapshot& get_entry(std::unique_ptr<DataSnapshot>& snap) {
   return *static_cast<IMRSnapshot*>(snap.get());
 }
 
-IMRMember::IMRMember(DataMember&& member, IMRGroup& my_group)
-  : DataMember(std::move(member)), group(my_group), send_buf(group.send_buf),
-    recv_buf(group.recv_buf) {}
-
 BuddyMember::BuddyMember(DataMember&& member, IMRGroup& my_group)
-  : IMRMember(std::move(member), my_group) {
+  : DataMember(std::move(member)), send_buf(my_group.send_buf),
+    recv_buf(my_group.recv_buf) {
   // Initialize snapshots (creates IMRSnapshot objects via virtual
   // create_snapshot)
   init_snapshots();
@@ -118,19 +125,20 @@ BuddyMember::BuddyMember(DataMember&& member, IMRGroup& my_group)
 }
 
 ParityMember::ParityMember(DataMember&& member, IMRGroup& my_group)
-  : IMRMember(std::move(member), my_group) {
+  : DataMember(std::move(member)), send_buf(my_group.send_buf),
+    recv_buf(my_group.recv_buf) {
   // Initialize snapshots (creates IMRSnapshot objects via virtual
   // create_snapshot)
   init_snapshots();
 
   int data_len   = user_data.is_bounded() ? user_data.size() : 0;
-  int parity_len = data_len / (group.set_size - 1);
+  int parity_len = data_len / (group->cohort_size - 1);
 
-  int remainder = data_len % (group.set_size - 1);
+  int remainder = data_len % (group->cohort_size - 1);
   if (remainder) remainder++;
-  if (remainder < group.set_rank) parity_len++;
+  if (remainder < group->cohort_rank) parity_len++;
 
-  // Resize partner buffers for staging snapshot
+  // Resize partner buffers for staging snapshot (parity_len is in bytes)
   get_entry(*stage_snapshot_).partner.resize(parity_len);
 
   // Resize partner buffers for available snapshots
@@ -139,150 +147,112 @@ ParityMember::ParityMember(DataMember&& member, IMRGroup& my_group)
   }
 }
 
-// Staging functions now use base class default implementations
+tasks::Task<int> BuddyMember::iprotect() {
+  const int rank  = group->cohort_rank;
+  const int left  = rank == 0 ? group->cohort_size - 1 : rank - 1;
+  const int right = rank == group->cohort_size - 1 ? 0 : rank + 1;
 
-tasks::Task<int> IMRMember::istorev(const DataSubset& subset) {
-  if (subset != SUBSET_PRESTAGED) stage(subset);
+  IMRSnapshot& snap = *static_cast<IMRSnapshot*>(stage_snapshot_.get());
 
-  if (subset != SUBSET_PRESTAGED && subset != SUBSET_FULL) {
-    return this->istorev_impl(subset);
-  } else {
-    return this->istorev_impl(get_entry(*stage_snapshot_).region());
-  }
-}
+  const DataSubset& subset         = snap.staged_subset();
+  const DataSubset& partner_subset = snap.staged_subsets[left];
 
-tasks::Task<int> BuddyMember::exch(
-  const DataSubset& subset, const DataSubset& partner_subset
-) {
-  const int rank  = group.set_rank;
-  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
-  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
+  snap.partner.add_and_fit(partner_subset);
+  int recv_count = partner_subset.count(snap.elm_max_count() - 1);
+  recv_buf.reset(snap.elm_size() * recv_count);
 
-  IMRSnapshot& e = get_entry(*stage_snapshot_);
-  e.partner.add_and_fit(partner_subset);
-
-  int recv_count = partner_subset.count(e.elm_max_count() - 1);
-  recv_buf.reset(e.elm_size() * recv_count);
-
-  subset.pack_data(e.elm_size(), e.buf(), send_buf);
+  subset.pack_data(snap.elm_size(), snap.buf(), send_buf);
   co_await tasks::mpi::sendrecv(
     send_buf.data(), send_buf.size(), MPI_BYTE, right, 0,
     recv_buf.data(), recv_buf.size(), MPI_BYTE,  left, 0,
-    group.set_comm
+    group->cohort_comm
   );
 
-  partner_subset.unpack_data(e.elm_size(), recv_buf, e.partner.buf());
+  partner_subset.unpack_data(snap.elm_size(), recv_buf, snap.partner.buf());
+
+  for (int i = 0; i < snap.staged_subsets.size(); i++) {
+    snap.protected_subsets[i] += snap.staged_subsets[i];
+    snap.staged_subsets[i] = {};
+  }
+
   co_return FENIX_SUCCESS;
 }
 
-tasks::Task<int> BuddyMember::istorev_impl(const DataSubset& subset) {
-  //My partner ranks (within set_comm)
-  const int rank  = group.set_rank;
-  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
-  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
-
-  DataBuffer send_buf, recv_buf;
-  subset.serialize(send_buf);
-
-  for (int i = 0; i < group.set_size; i++) {
-    if (i == rank) co_await send_buf.send(right, 0, group.set_comm);
-    if (i == left) co_await recv_buf.recv_unknown(left, 0, group.set_comm);
+std::vector<int> ParityMember::prepare_for_parity(IMRSnapshot& snap) {
+  size_t data_count = 0;
+  for (const auto& subset : snap.staged_subsets) {
+    data_count = std::max(data_count, subset.max_count());
+  }
+  for (const auto& subset : snap.protected_subsets) {
+    data_count = std::max(data_count, subset.max_count());
   }
 
-  DataSubset partner_subset(recv_buf);
-  co_return co_await exch(subset, partner_subset);
+  int data_bytes = data_count * snap.elm_size();
+  int n_partners = snap.staged_subsets.size() - 1;
+
+  int parity_bytes    = data_bytes / n_partners;
+  int remainder_bytes = data_bytes % n_partners;
+
+  // If we have any remainder, we need one extra remainder, since the ranks that
+  // calculate the 1-larger parity are missing one byte of protection.
+  if (remainder_bytes) remainder_bytes++;
+
+  std::vector<int> ret(n_partners + 1, parity_bytes);
+  for (int i = 0; i < remainder_bytes; i++) ++ret[i];
+  int local_parity = ret[group->cohort_rank];
+
+  if (snap.size() < data_bytes) snap.resize(data_bytes);
+  snap.partner.resize(local_parity);
+
+  return ret;
 }
 
-tasks::Task<int> IMRMember::istore(const DataSubset& subset) {
-  if (subset != SUBSET_PRESTAGED) stage(subset);
+tasks::Task<int> ParityMember::iprotect() {
+  IMRSnapshot& snap = *static_cast<IMRSnapshot*>(stage_snapshot_.get());
+  auto parity_bytes = prepare_for_parity(snap);
 
-  if (subset != SUBSET_PRESTAGED && subset != SUBSET_FULL) {
-    return this->istore_impl(subset);
-  } else {
-    return this->istore_impl(get_entry(*stage_snapshot_).region());
-  }
-}
-
-tasks::Task<int> BuddyMember::istore_impl(const DataSubset& subset) {
-  return exch(subset, subset);
-}
-
-tasks::Task<int> ParityMember::istore_impl(const DataSubset& subset) {
-  IMRSnapshot& entry = get_entry(*stage_snapshot_);
-
-  int parity_size = entry.size() / (group.set_size - 1);
-  int remainder   = entry.size() % (group.set_size - 1);
-
-  //If we have any remainder, treat as if we have one more, since a rank
-  //storing a larger parity block wasn't able to store a larger data block, so
-  //all such ranks need one extra larger data block.
-  if (remainder) remainder++;
-
-  int m_parity_size = parity_size;
-  if (group.set_rank < remainder) m_parity_size++;
-  entry.partner.resize(m_parity_size);
+  fenix_assert(parity_bytes.size() == group->cohort_size);
 
   //Zero out the parity data before computing, so old data doesn't contribute
-  std::memset(entry.partner.data(), 0, entry.partner.size());
+  std::memset(snap.partner.data(), 0, snap.partner.size());
 
   int offset = 0;
-  for (int i = 0; i < group.set_size; i++) {
-    int len = i < remainder ? parity_size + 1 : parity_size;
+  for (int root = 0; root < parity_bytes.size(); root++) {
+    int len = parity_bytes[root];
+
+    bool local_root = group->cohort_rank == root;
 
     char* input;
-    if (group.set_rank == i) {
-      //The rank storing this parity region contributes the all zero input
-      //as a way of not contributing
-      input = entry.partner.data();
+    if (local_root) {
+      input = snap.partner.data();
     } else {
-      if (offset + len > entry.size()) {
-        //Since we pretend to have an extra remainder if there is any
-        assert(remainder);
-        assert(group.set_rank >= remainder);
-        assert(offset + len == entry.size() + 1);
+      input = snap.data() + offset;
+      offset += len;
+      if (input + len > snap.data() + snap.size()) {
+        fenix_assert(input + len == snap.data() + snap.size() + 1);
+        input--;
         offset--;
       }
-      input = entry.data() + offset;
-      offset += len;
     }
 
     co_await tasks::mpi::reduce(
-      MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, i, group.set_comm
+      local_root ? MPI_IN_PLACE : input, input, len, MPI_BYTE, MPI_BXOR, root,
+      group->cohort_comm
     );
   }
 
-  assert(offset == entry.size());
+  for (int i = 0; i < snap.staged_subsets.size(); i++) {
+    snap.protected_subsets[i] += snap.staged_subsets[i];
+    snap.staged_subsets[i] = {};
+  }
   co_return FENIX_SUCCESS;
 }
 
-void IMRMember::repair() {
-  // Remove committed snapshots not in group's timestamp list
-  for (auto it = commit_snapshots_.begin(); it != commit_snapshots_.end();) {
-    auto found = std::find(
-      group.timestamps.begin(), group.timestamps.end(), (*it)->timestamp()
-    );
-    if (found != group.timestamps.end()) {
-      ++it;
-      continue;
-    }
-
-    // Not in group timestamps, extract and move to available pool
-    std::unique_ptr<DataSnapshot> snap =
-      std::move(commit_snapshots_.extract(it++).value());
-    snap->reset();
-    avail_snapshots_.push_back(std::move(snap));
-  }
-
-  // Reset the current store buffer entry
-  get_entry(*stage_snapshot_).reset();
-  this->repair_impl();
-}
-
-void BuddyMember::repair_impl() {
+void BuddyMember::repair() {
   //My partner ranks (within set_comm)
-  const int rank  = group.set_rank;
-  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
-  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
+  const int rank  = group->cohort_rank;
+  const int left  = rank == 0 ? group->cohort_size - 1 : rank - 1;
+  const int right = rank == group->cohort_size - 1 ? 0 : rank + 1;
 
   //Data on which partners have found each snapshot
   int found[3];
@@ -290,8 +260,11 @@ void BuddyMember::repair_impl() {
   int& found_left  = found[left];
   int& found_right = found[right];
 
+  // Reinitialize cohort in stage snapshot
+  stage_snapshot_->reinit_cohort(group->cohort_comm);
+
   // Iterate through committed timestamps (newest to oldest)
-  for (const int& ts : group.timestamps) {
+  for (const int& ts : group->timestamps) {
     auto snap_it = commit_snapshots_.find(ts);
 
     found_here = snap_it != commit_snapshots_.end();
@@ -299,71 +272,79 @@ void BuddyMember::repair_impl() {
 
     DataSnapshot& snap = found_here ? **snap_it : *avail_snapshots_.back();
     IMRSnapshot& e     = get_entry(snap);
+    if (!found_here) e.reset();
 
-    MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, found, 1, MPI_INT, group.set_comm);
+    MPI_Allgather(
+      MPI_IN_PLACE, 1, MPI_INT, found, 1, MPI_INT, group->cohort_comm
+    );
 
-    int n_missing = 0;
-    for (int i = 0; i < group.set_size; i++) n_missing += found[i] ? 0 : 1;
+    int n_missing = 0, bcast_root = -1;
+    for (int i = 0; i < group->cohort_size; i++) {
+      if (found[i]) bcast_root = i;
+      else n_missing++;
+    }
+
     if (n_missing == 0) continue;
     if (n_missing > 1) {
-      if (group.set_rank == 0) {
+      if (group->cohort_rank == 0) {
         debug_print(
           "WARNING Fenix_Data_member_restore: %s member %d timestamp %d "
           "unrecoverable",
-          group.str().c_str(), id, ts
+          group->str().c_str(), memberid, ts
         );
       }
       continue;
     }
 
-    if (!found_here) {
-      //Fetch my data region from right partner
-      recv_buf.recv_unknown(right, 0, group.set_comm).wait();
-      e.add_and_fit({recv_buf});
-      //Fetch my data
-      int m_count = e.region().count(e.elm_max_count() - 1);
-      recv_buf.recv(m_count * e.elm_size(), right, 0, group.set_comm).wait();
-      e.region().unpack_data(e.elm_size(), recv_buf, e.buf());
+    e.reinit_cohort(group->cohort_comm);
+    broadcast_subsets(e.protected_subsets, bcast_root).wait();
 
-      //Fetch left partner's region
-      recv_buf.recv_unknown(left, 0, group.set_comm).wait();
-      e.partner.add_and_fit({recv_buf});
-      //Fetch data
-      int p_count = e.partner.region().count(e.elm_max_count() - 1);
-      recv_buf.recv(p_count * e.elm_size(), left, 0, group.set_comm).wait();
-      e.partner.region().unpack_data(e.elm_size(), recv_buf, e.partner.buf());
+    if (!found_here) {
+      //Fetch my data
+      e.add_and_fit(e.protected_subset());
+      int m_count = e.protected_subset().count(e.elm_max_count() - 1);
+      recv_buf.recv(m_count * e.elm_size(), right, 0, group->cohort_comm)
+        .wait();
+      e.protected_subset().unpack_data(e.elm_size(), recv_buf, e.buf());
+
+      //Fetch partner's data
+      e.partner.add_and_fit(e.protected_subsets[left]);
+      int p_count = e.partner.staged_subset().count(e.elm_max_count() - 1);
+      recv_buf.recv(p_count * e.elm_size(), left, 0, group->cohort_comm).wait();
+      e.partner.staged_subset().unpack_data(
+        e.elm_size(), recv_buf, e.partner.buf()
+      );
 
       e.set_timestamp(ts);
       commit_snapshots_.insert(std::move(avail_snapshots_.back()));
       avail_snapshots_.pop_back();
     }
     if (!found_left) {
-      //Send partner's data region
-      e.partner.region().serialize(send_buf);
-      send_buf.send(left, 0, group.set_comm).wait();
       //Send their data
-      e.partner.region().pack_data(e.elm_size(), e.partner.buf(), send_buf);
-      send_buf.send(left, 0, group.set_comm).wait();
+      e.partner.staged_subset().pack_data(
+        e.elm_size(), e.partner.buf(), send_buf
+      );
+      send_buf.send(left, 0, group->cohort_comm).wait();
     }
     if (!found_right) {
-      //Send my data region
-      e.region().serialize(send_buf);
-      send_buf.send(right, 0, group.set_comm).wait();
       //Send my data
-      e.region().pack_data(e.elm_size(), e.buf(), send_buf);
-      send_buf.send(right, 0, group.set_comm).wait();
+      e.protected_subset().pack_data(e.elm_size(), e.buf(), send_buf);
+      send_buf.send(right, 0, group->cohort_comm).wait();
     }
   }
 }
 
-void ParityMember::repair_impl() {
+void ParityMember::repair() {
   //Data on which partners have found each snapshot
   std::vector<int> found;
-  found.resize(group.set_size);
+  found.resize(group->cohort_size);
   int found_here;
 
+  // Reinitialize cohort in stage snapshot
+  stage_snapshot_->reinit_cohort(group->cohort_comm);
+
   // Iterate through committed timestamps (newest to oldest)
-  for (const int& ts : group.timestamps) {
+  for (const int& ts : group->timestamps) {
     auto snap_it = commit_snapshots_.find(ts);
 
     found_here = snap_it != commit_snapshots_.end();
@@ -371,20 +352,21 @@ void ParityMember::repair_impl() {
 
     DataSnapshot& snap = found_here ? **snap_it : *avail_snapshots_.back();
     IMRSnapshot& e     = get_entry(snap);
+    if (!found_here) e.reset();
 
     MPI_Allgather(
-      &found_here, 1, MPI_INT, found.data(), 1, MPI_INT, group.set_comm
+      &found_here, 1, MPI_INT, found.data(), 1, MPI_INT, group->cohort_comm
     );
 
     int recovering = -1;
-    for (int i = 0; i < group.set_size; i++) {
+    for (int i = 0; i < group->cohort_size; i++) {
       if (found[i]) continue;
       if (recovering != -1) {
-        if (group.set_rank == 0) {
+        if (group->cohort_rank == 0) {
           debug_print(
             "WARNING Fenix_Data_member_restore: %s member %d timestamp %d "
             "unrecoverable",
-            group.str().c_str(), id, ts
+            group->str().c_str(), memberid, ts
           );
         }
         recovering = -1;
@@ -394,24 +376,13 @@ void ParityMember::repair_impl() {
       }
     }
     if (recovering == -1) continue;
+    e.reinit_cohort(group->cohort_comm);
 
+    // Broadcast protected_subsets from a sender who has the data
     int sender = recovering == 0 ? 1 : 0;
-    if (group.set_rank == sender) {
-      e.region().serialize(send_buf);
-      send_buf.send(recovering, 0, group.set_comm).wait();
-    } else if (!found_here) {
-      recv_buf.recv_unknown(sender, 0, group.set_comm).wait();
-      e.add_and_fit({recv_buf});
-    }
+    broadcast_subsets(e.protected_subsets, sender).wait();
 
-    //Use the same logic as store, but recovering rank is always root and
-    //zeroes out the local data region before participating.
-    int parity_size = e.size() / (group.set_size - 1);
-    int remainder   = e.size() % (group.set_size - 1);
-    if (remainder) remainder++;
-    int m_parity_size = parity_size;
-    if (group.set_rank < remainder) m_parity_size++;
-    e.partner.resize(m_parity_size);
+    auto parity_bytes = prepare_for_parity(e);
 
     if (!found_here) {
       std::memset(e.data(), 0, e.size());
@@ -419,21 +390,26 @@ void ParityMember::repair_impl() {
     }
 
     int offset = 0;
-    for (int i = 0; i < group.set_size; i++) {
-      int len = i < remainder ? parity_size + 1 : parity_size;
+    for (int i = 0; i < parity_bytes.size(); i++) {
+      int len = parity_bytes[i];
+
       char* input;
-      if (group.set_rank == i) {
+      if (group->cohort_rank == i) {
         input = e.partner.data();
       } else {
-        if (offset + len > e.size()) offset--;
         input = e.data() + offset;
         offset += len;
+        if (input + len > snap.data() + snap.size()) {
+          fenix_require(input + len == snap.data() + snap.size() + 1);
+          input--;
+          offset--;
+        }
       }
       MPI_Reduce(
-        MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, recovering, group.set_comm
+        found_here ? input : MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR,
+        recovering, group->cohort_comm
       );
     }
-    assert(offset == e.size());
 
     if (!found_here) {
       e.set_timestamp(ts);
@@ -443,38 +419,39 @@ void ParityMember::repair_impl() {
   }
 }
 
-IMRGroup::IMRGroup(
-  int m_id, MPI_Comm m_comm, int m_timestart, int m_depth, int* policy_vals
-)
-  : DataGroup(m_id, m_comm, m_timestart, m_depth, FENIX_DATA_POLICY_IMR) {
-  mode = policy_vals ? policy_vals[0] : 1;
-  rank_separation =
-    policy_vals ? policy_vals[1] : __fenix_get_world_size(m_comm) / 2;
+int IMRGroup::get_mode(int* policy_vals) {
+  return policy_vals ? policy_vals[0] : 1;
+}
 
-  comm = m_comm;
+int IMRGroup::get_rank_sep(int* policy_vals, MPI_Comm comm) {
+  return policy_vals ? policy_vals[1] : __fenix_get_world_size(comm) / 2;
+}
+
+MPI_Group IMRGroup::create_cohort() {
+  int mode_val     = mode;
+  int rank_sep_val = rank_separation;
 
   int my_rank, comm_size;
   MPI_Comm_size(comm, &comm_size);
   MPI_Comm_rank(comm, &my_rank);
-  current_rank = my_rank;
 
   std::set<int> partner_set;
   partner_set.insert(my_rank);
 
-  if (mode == 1) {
+  if (mode_val == 1) {
     //odd-sized groups take some extra handling.
     bool isOdd = ((comm_size % 2) != 0);
 
     int remaining_size = comm_size;
     if (isOdd) remaining_size -= 3;
 
-    //We want to form groups of rank_separation*2 to pair within
-    int n_full_groups = remaining_size / (rank_separation * 2);
+    //We want to form groups of rank_sep_val*2 to pair within
+    int n_full_groups = remaining_size / (rank_sep_val * 2);
 
     //We don't always get what we want though, one group may need to be
     //smaller.
     int mini_group_size =
-      (remaining_size - n_full_groups * rank_separation * 2) / 2;
+      (remaining_size - n_full_groups * rank_sep_val * 2) / 2;
 
     int start_rank = mini_group_size + (isOdd ? 1 : 0);
     int mid_rank   = comm_size / 2; //Only used when isOdd
@@ -495,12 +472,12 @@ IMRGroup::IMRGroup(
       if (isOdd && my_rank > mid_rank) --e_rank; //Skip middle rank when isOdd
 
       int my_partner;
-      if (((e_rank / rank_separation) % 2) == 0) {
+      if (((e_rank / rank_sep_val) % 2) == 0) {
         //Look forward for partner.
-        my_partner = my_rank + rank_separation;
+        my_partner = my_rank + rank_sep_val;
         if (isOdd && my_rank < mid_rank && my_partner >= mid_rank) ++my_partner;
       } else {
-        my_partner = my_rank - rank_separation;
+        my_partner = my_rank - rank_sep_val;
         if (isOdd && my_rank > mid_rank && my_partner <= mid_rank) --my_partner;
       }
 
@@ -524,77 +501,41 @@ IMRGroup::IMRGroup(
         (partner_set.size() == 3 || (comm_size == 1 && partner_set.size() == 1))
       );
     }
-  } else if (mode == 5) {
-    set_size = policy_vals[2];
+  } else if (mode_val == 5) {
+    int set_size_val = set_size_policy;
 
     //User is responsible for giving values that "make sense" for set size and
     //rank separation given a comm size.
-    int my_set_pos = (my_rank / rank_separation) % set_size;
-    for (int i = 0; i < set_size; i++) {
+    int my_set_pos = (my_rank / rank_sep_val) % set_size_val;
+    for (int i = 0; i < set_size_val; i++) {
       int partner =
-        (comm_size + my_rank - rank_separation * (my_set_pos - i)) % comm_size;
+        (comm_size + my_rank - rank_sep_val * (my_set_pos - i)) % comm_size;
       partner_set.insert(partner);
     }
   }
 
-  partners = {partner_set.begin(), partner_set.end()};
-
-  //Make same MPI calls as reinit
-  reinit();
-}
-
-void IMRGroup::build_set_comm() {
-  if (set_comm != MPI_COMM_NULL) {
-    MPI_Comm_free(&set_comm);
-    set_comm = MPI_COMM_NULL;
-  }
-
-  MPI_Group comm_group, set_group;
+  // Create cohort group from computed partners
+  std::vector<int> partner_vec(partner_set.begin(), partner_set.end());
+  MPI_Group comm_group, cohort_group;
   MPI_Comm_group(comm, &comm_group);
-  MPI_Group_incl(comm_group, partners.size(), partners.data(), &set_group);
-  MPI_Comm_create_group(comm, set_group, 0, &(set_comm));
-
+  MPI_Group_incl(
+    comm_group, partner_vec.size(), partner_vec.data(), &cohort_group
+  );
   MPI_Group_free(&comm_group);
-  MPI_Group_free(&set_group);
-
-  MPI_Comm_size(set_comm, &set_size);
-  MPI_Comm_rank(set_comm, &set_rank);
-
-  if (!set_comm_revoke_callback) {
-    //TODO: This isn't great, and doesn't work w/ fenix restarts
-    // (ie finalize then init), we need a better way to refer to callbacks
-    // than just push/pop. Maybe a push/pop stack and an add/del map?
-    set_comm_revoke_callback = true;
-    fenix::callback_register(
-      [](MPI_Comm, int) {
-        auto dc = fenix_rt.data_recovery;
-        if (NULL == dc) return;
-        for (auto& group_ptr : dc->groups) {
-          auto g = group_ptr.get();
-          if (g->policy_name != FENIX_DATA_POLICY_IMR) continue;
-          auto imr_g = static_cast<fenix::data::imr::IMRGroup*>(g);
-
-          if (imr_g->set_comm == MPI_COMM_NULL) continue;
-          MPIX_Comm_revoke(imr_g->set_comm);
-        }
-      },
-      PRE_RECOVERY
-    );
-  }
+  return cohort_group;
 }
 
-std::string IMRGroup::str() {
-  std::stringstream ss;
-  ss << "Group " << groupid << " set ";
-  ss << "[" << partners[0];
-  for (int i = 1; i < partners.size(); i++) ss << ", " << partners[i];
-  ss << "]";
-  return ss.str();
-}
+IMRGroup::IMRGroup(
+  int m_id, MPI_Comm m_comm, int m_timestart, int m_depth, int* policy_vals
+)
+  : DataGroup(m_id, m_comm, m_timestart, m_depth, FENIX_DATA_POLICY_IMR),
+    mode(get_mode(policy_vals)),
+    rank_separation(get_rank_sep(policy_vals, m_comm)),
+    set_size_policy(policy_vals && mode == 5 ? policy_vals[2] : 0) {}
 
 void IMRGroup::emplace_member(DataMember&& member) {
   // Create and insert the policy-specific Member into members map
-  std::shared_ptr<IMRMember> m;
+  std::shared_ptr<DataMember> m;
   if (mode == 1) {
     m = std::make_shared<BuddyMember>(std::move(member), *this);
   } else if (mode == 5) {
@@ -614,54 +555,10 @@ void IMRGroup::commit() {
 }
 
 void IMRGroup::member_repair(int member_id) {
-  DataMember* member = search_member(member_id);
+  // Call parent to handle member repair across cohort
+  DataGroup::member_repair(member_id);
 
-  std::vector<int> found_members(set_size);
-  found_members[set_rank] = member ? 1 : 0;
-
-  int allgather_ret = MPI_Allgather(
-    MPI_IN_PLACE, 1, MPI_INT, found_members.data(), 1, MPI_INT, set_comm
-  );
-
-  int n_missing   = 0;
-  int first_found = -1, missing_rank = -1;
-  for (int i = 0; i < found_members.size(); i++) {
-    if (!found_members[i]) {
-      n_missing++;
-      missing_rank = i;
-    }
-    if (found_members[i] && first_found == -1) first_found = i;
-  }
-
-  if (n_missing > 1) {
-    if (set_rank != 0) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-
-    if (n_missing == set_size) {
-      debug_print(
-        "ERROR %s member_id %d not found\n", this->str().c_str(), member_id
-      );
-    } else {
-      debug_print(
-        "ERROR %s member_id %d unrecoverable\n", this->str().c_str(), member_id
-      );
-    }
-    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-  } else if (n_missing == 1) {
-    DataMemberPacket packet;
-    if (set_rank == first_found) packet = member->to_packet();
-
-    MPI_Bcast(&packet, sizeof(packet), MPI_BYTE, first_found, set_comm);
-
-    if (!found_members[set_rank]) {
-      DataGroup::member_create(
-        packet.memberid, nullptr, packet.current_count, packet.datatype_size
-      );
-      member = find_member(member_id);
-    }
-  }
-
-  member->repair();
-
+  // Clear IMR-specific buffers
   send_buf.clear();
   send_buf.shrink_to_fit();
   recv_buf.clear();
@@ -675,31 +572,20 @@ void IMRGroup::member_restore_from_rank(
   fenix_assert(false, "restore_from_rank is not supported yet!");
 }
 
-void IMRGroup::reinit() {
-  build_set_comm();
-  sync_timestamps();
-}
+void IMRGroup::init() {
+  // Call parent to create cohort and cohort_comm (includes sync_timestamps)
+  DataGroup::init();
 
-void IMRGroup::sync_timestamps() {
-  int n_snapshots = timestamps.size();
-  MPI_Allreduce(MPI_IN_PLACE, &n_snapshots, 1, MPI_INT, MPI_MAX, set_comm);
-
-  // Create vector with current timestamps, pad with -1 if needed
-  std::vector<int> ts(timestamps.begin(), timestamps.end());
-  ts.resize(n_snapshots, -1);
-
-  MPI_Allreduce(
-    MPI_IN_PLACE, ts.data(), n_snapshots, MPI_INT, MPI_MAX, set_comm
-  );
-
-  // Rebuild set from vector (automatically reverse sorted)
-  timestamps.clear();
-  for (int t : ts) {
-    timestamps.insert(t);
+  // Validate parity mode requirements
+  if (mode == 5 && cohort_size < 3) {
+    if (cohort_rank == 0) {
+      debug_print(
+        "ERROR: Parity mode (mode 5) requires cohort_size >= 3, but got %d",
+        cohort_size
+      );
+    }
+    FENIX_THROW(FENIX_ERROR_INVALID_POLICY_VALUE);
   }
-
-  if (!timestamps.empty()) timestamp = *timestamps.begin(); // Newest first
-  else timestamp = -1;
 }
 
 void IMRGroup::get_redundant_policy(int* policy_name, void* policy_value) {
@@ -708,7 +594,7 @@ void IMRGroup::get_redundant_policy(int* policy_name, void* policy_value) {
   int* policy_vals = (int*)policy_value;
   policy_vals[0]   = mode;
   policy_vals[1]   = rank_separation;
-  if (mode == 5) policy_vals[2] = set_size;
+  if (mode == 5) policy_vals[2] = set_size_policy;
 }
 
 } // namespace fenix::data::imr

--- a/src/data/recovery.cpp
+++ b/src/data/recovery.cpp
@@ -471,6 +471,14 @@ std::optional<std::vector<int>> group_snapshots(int group_id) {
   return {};
 }
 
+MPI_Group group_cohort(int group_id) {
+  assert(initialized());
+  auto group = fenix_rt.data_recovery->find_group(group_id);
+  MPI_Group cohort;
+  MPI_Comm_group(group->cohort_comm, &cohort);
+  return cohort;
+}
+
 int snapshot_delete(int group_id, int time_stamp) {
   FENIX_CPP_API_BEGIN
   if (time_stamp < 0) FENIX_THROW(FENIX_ERROR_INVALID_TIMESTAMP);
@@ -513,6 +521,14 @@ int Fenix_Data_group_get_snapshot_at_position(
     fenix_rt.data_recovery->find_group(groupid)->get_snapshot_at_position(
       position
     );
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
+}
+
+int Fenix_Data_group_get_cohort(int group_id, MPI_Group* cohort) {
+  FENIX_C_API_BEGIN
+  auto group = fenix_rt.data_recovery->find_group(group_id);
+  MPI_Comm_group(group->cohort_comm, cohort);
   return FENIX_SUCCESS;
   FENIX_C_API_END
 }

--- a/src/data/snapshot.cpp
+++ b/src/data/snapshot.cpp
@@ -12,20 +12,85 @@ DataSnapshot::DataSnapshot(int elm_size, int max_count)
 void DataSnapshot::reset() {
   timestamp_ = -2;
   buf_.clear();
-  region_ = {};
+  protected_subsets.clear();
+  staged_subsets.clear();
+  cohort_rank = -1;
+  if (cohort_ != MPI_GROUP_NULL) {
+    MPI_Group_free(&cohort_);
+    cohort_ = MPI_GROUP_NULL;
+  }
+}
+
+void DataSnapshot::init_cohort(MPI_Comm cohort_comm) {
+  if (cohort_ == MPI_GROUP_NULL) {
+    MPI_Comm_group(cohort_comm, &cohort_);
+
+    // Get cohort size and this rank's position
+    int cohort_size;
+    MPI_Group_size(cohort_, &cohort_size);
+    MPI_Comm_rank(cohort_comm, &cohort_rank);
+
+    // Allocate vectors (one per cohort member, including self)
+    protected_subsets.resize(cohort_size);
+    staged_subsets.resize(cohort_size);
+  }
+}
+
+void DataSnapshot::reinit_cohort(MPI_Comm cohort_comm) {
+  // Free existing cohort if present
+  if (cohort_ != MPI_GROUP_NULL) {
+    MPI_Group_free(&cohort_);
+  }
+
+  // Get fresh cohort group
+  MPI_Comm_group(cohort_comm, &cohort_);
+
+  // Get cohort size and this rank's position
+  int cohort_size;
+  MPI_Group_size(cohort_, &cohort_size);
+  MPI_Comm_rank(cohort_comm, &cohort_rank);
+
+  // Allocate or resize vectors (one per cohort member, including self)
+  protected_subsets.resize(cohort_size);
+  staged_subsets.resize(cohort_size);
+}
+
+util::Serializer DataSnapshot::create_serializer(
+  const util::DataRef& source, std::optional<SerializeFunc>& sf,
+  const DataSubset& subset
+) {
+  util::DataRef output = source;
+  if (subset.is_bounded()) {
+    output = output.bounded(subset.max_count() * elm_size_);
+  }
+
+  if (output.is_bounded()) {
+    if (buf_.size() < output.size()) buf_.resize(output.size());
+  } else if (!sf) {
+    FENIX_THROW(FENIX_ERROR_INVALID_SUBSET);
+  }
+
+  return util::Serializer(buf_, sf, output, FENIX_SERIALIZE, elm_size_);
+}
+
+util::Serializer DataSnapshot::create_deserializer(
+  const util::DataRef& dst, std::optional<SerializeFunc>& sf,
+  const DataSubset& subset
+) {
+  return util::Serializer(buf_, sf, dst, FENIX_DESERIALIZE, elm_size_);
 }
 
 void DataSnapshot::add_and_fit(const DataSubset& subset) {
   fenix_assert(subset != SUBSET_PRESTAGED);
-  fenix_assert(region_ != SUBSET_PRESTAGED);
-  fenix_assert(region_.max_count() > 0 || region_.empty());
+  fenix_assert(staged_subset() != SUBSET_PRESTAGED);
+  fenix_assert(staged_subset().max_count() > 0 || staged_subset().empty());
 
-  region_ += subset;
-  if (elm_max_count_) region_.bound(elm_max_count_ - 1);
+  staged_subset() += subset;
+  if (elm_max_count_) staged_subset().bound(elm_max_count_ - 1);
 
   int new_count = elm_max_count_;
-  if (!new_count) new_count = region_.max_count();
-  fenix_assert(new_count || region_.empty());
+  if (!new_count) new_count = staged_subset().max_count();
+  fenix_assert(new_count || staged_subset().empty());
 
   int new_size = new_count * elm_size_;
   if (new_size > buf_.size()) buf_.resize(new_size);

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -786,10 +786,10 @@ void __fenix_finalize_spare() {
 }
 
 void __fenix_test_MPI(MPI_Comm* pcomm, int* pret, ...) {
+  if (!fenix_rt.fenix_init_flag) return;
+
   util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
   fenix_rt.mpi_fail_code = *pret;
-
-  if (!fenix_rt.fenix_init_flag) return;
 
   constexpr bool throw_new = true;
 
@@ -808,6 +808,9 @@ void __fenix_test_MPI(MPI_Comm* pcomm, int* pret, ...) {
     MPIX_Comm_revoke(*fenix_rt.world);
     MPIX_Comm_revoke(fenix_rt.new_world);
     if (fenix_rt.user_world_exists) MPIX_Comm_revoke(*fenix_rt.user_world);
+
+    // Revoke all data recovery cohort communicators
+    if (fenix_rt.data_recovery) fenix_rt.data_recovery->revoke();
 
     callback_invoke_all(fenix::PRE_RECOVERY);
     fenix_rt.repair_result = __fenix_repair_ranks();

--- a/test/group_query/CMakeLists.txt
+++ b/test/group_query/CMakeLists.txt
@@ -9,4 +9,4 @@
 #
 
 fenix_test(SRC group_query.cpp RANKS 2)
-fenix_test(SRC redundancy_policy.cpp RANKS 2)
+fenix_test(SRC redundancy_policy.cpp RANKS 3)

--- a/test/group_query/redundancy_policy.cpp
+++ b/test/group_query/redundancy_policy.cpp
@@ -71,6 +71,9 @@ int main(int argc, char** argv) {
   MPI_Comm_size(res_comm, &num_ranks);
   MPI_Comm_rank(res_comm, &rank);
 
+  // Test requires at least 3 ranks for parity mode
+  fenix_require(num_ranks >= 3);
+
   if (rank == 0) fprintf(stderr, "Test: Query redundancy policy\n");
 
   // Create a group with FENIX_DATA_POLICY_IN_MEMORY_RAID policy

--- a/test/storev/CMakeLists.txt
+++ b/test/storev/CMakeLists.txt
@@ -9,3 +9,5 @@
 #
 
 fenix_test(SRC storev.cpp RANKS 6)
+fenix_test(SRC store_parity.cpp RANKS 7)
+fenix_test(SRC storev_parity.cpp RANKS 7)

--- a/test/storev/store_parity.cpp
+++ b/test/storev/store_parity.cpp
@@ -1,0 +1,147 @@
+#include <fenix.hpp>
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <vector>
+
+constexpr int kKillID         = 2;
+constexpr int my_group        = 0;
+constexpr int my_member       = 0;
+constexpr int start_timestamp = 0;
+constexpr int group_depth     = 1;
+int errflag;
+
+using fenix::DataSubset;
+using namespace fenix::data;
+
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
+
+  MPI_Comm res_comm;
+  fenix::init({.out_comm = &res_comm, .spares = 1});
+
+  int num_ranks, rank;
+  MPI_Comm_size(res_comm, &num_ranks);
+  MPI_Comm_rank(res_comm, &rank);
+
+  // Use fixed size data (same for all ranks) for parity mode
+  constexpr int kDataSize = 100;
+  std::vector<int> data(kDataSize);
+
+  bool should_throw = Fenix_get_role() == FENIX_ROLE_RECOVERED_RANK;
+  while (true) {
+    try {
+      if (should_throw) {
+        should_throw = false;
+        fenix::throw_exception();
+      }
+
+      //Initial work and commits
+      if (Fenix_get_role() == FENIX_ROLE_INITIAL_RANK) {
+        // Use IMR mode 5 (parity) with set size of 3, rank separation of 1
+        // With 6 ranks and set_size=3, we get 2 sets of 3 ranks each
+        int policy_vals[] = {5, 1, 3};
+        Fenix_Data_group_create(
+          my_group, res_comm, start_timestamp, group_depth,
+          FENIX_DATA_POLICY_IMR, policy_vals, &errflag
+        );
+        if (errflag != FENIX_SUCCESS) {
+          fprintf(
+            stderr, "Rank %d: group create failed with %d\n", rank, errflag
+          );
+          exit(1);
+        }
+
+        Fenix_Data_member_create(
+          my_group, my_member, data.data(), kDataSize, MPI_INT
+        );
+
+        // Initialize data
+        for (int i = 0; i < kDataSize; i++) {
+          data[i] = rank * 1000 + i;
+        }
+
+        // Store and commit
+        member_store(my_group, my_member);
+        Fenix_Data_commit_barrier(my_group, NULL);
+
+        fprintf(stderr, "Rank %d: Store and commit successful\n", rank);
+
+        if (rank == kKillID) {
+          fprintf(stderr, "Doing kill on rank %d\n", rank);
+          raise(SIGTERM);
+        }
+      }
+
+      Fenix_Finalize();
+      break;
+    } catch (const fenix::CommException& e) {
+      const fenix::CommException* err = &e;
+      while (true) {
+        try {
+          //We've had a failure! Time to recover data.
+          fprintf(stderr, "Starting data recovery on rank %d\n", rank);
+          if (err->fenix_err != FENIX_SUCCESS) {
+            fprintf(
+              stderr, "FAILURE on Fenix Init (%d). Exiting.\n", err->fenix_err
+            );
+            exit(1);
+          }
+
+          //Repair the group from the spare
+          Fenix_Data_group_create(
+            my_group, res_comm, start_timestamp, group_depth,
+            FENIX_DATA_POLICY_IMR, (int[]){5, 1, 3}, &errflag
+          );
+
+          //Restore data
+          DataSubset stored_subset;
+          int ret = member_restore(
+            my_group, my_member, nullptr, 0, FENIX_DATA_SNAPSHOT_LATEST,
+            stored_subset
+          );
+          if (ret != FENIX_SUCCESS) {
+            fprintf(stderr, "Rank %d restore failure w/ code %d\n", rank, ret);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+          }
+
+          //Load the data
+          ret = member_lrestore(
+            my_group, my_member, data.data(), kDataSize,
+            FENIX_DATA_SNAPSHOT_LATEST, stored_subset
+          );
+          if (ret != FENIX_SUCCESS) {
+            fprintf(stderr, "Rank %d lrestore failure w/ code %d\n", rank, ret);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+          }
+
+          //Validate restored data
+          bool successful   = true;
+          int expected_base = rank * 1000;
+          for (int i = 0; i < kDataSize && successful; i++) {
+            if (data[i] != expected_base + i) {
+              fprintf(
+                stderr, "FAILURE rank %d: data[%d] = %d, expected %d\n", rank,
+                i, data[i], expected_base + i
+              );
+              successful = false;
+            }
+          }
+          fenix_require(successful);
+
+          fprintf(
+            stderr, "SUCCESS: Data restored correctly on rank %d\n", rank
+          );
+
+          break;
+        } catch (const fenix::CommException& e) {
+          fatal_print("Nested CommException during recovery");
+        }
+      }
+    }
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/test/storev/storev_parity.cpp
+++ b/test/storev/storev_parity.cpp
@@ -1,0 +1,213 @@
+#include <fenix.hpp>
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+constexpr int kKillID         = 2;
+constexpr int my_group        = 0;
+constexpr int my_member       = 0;
+constexpr int start_timestamp = 0;
+constexpr int group_depth     = 1;
+int errflag;
+
+using fenix::DataSubset;
+using namespace fenix::data;
+
+int main(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
+
+  MPI_Comm res_comm;
+  fenix::init({.out_comm = &res_comm, .spares = 1});
+
+  int num_ranks, rank;
+  MPI_Comm_size(res_comm, &num_ranks);
+  MPI_Comm_rank(res_comm, &rank);
+
+  std::vector<int> data;
+
+  bool should_throw = Fenix_get_role() == FENIX_ROLE_RECOVERED_RANK;
+  while (true) {
+    try {
+      if (should_throw) {
+        should_throw = false;
+        fenix::throw_exception();
+      }
+
+      //Initial work and commits
+      if (Fenix_get_role() == FENIX_ROLE_INITIAL_RANK) {
+        // Use IMR mode 5 (parity) with set size of 3, rank separation of 1
+        // With 6 ranks and set_size=3, we get 2 sets of 3 ranks each
+        int policy_vals[] = {5, 1, 3};
+        Fenix_Data_group_create(
+          my_group, res_comm, start_timestamp, group_depth,
+          FENIX_DATA_POLICY_IMR, policy_vals, &errflag
+        );
+        Fenix_Data_member_create(
+          my_group, my_member, data.data(), FENIX_RESIZEABLE, MPI_INT
+        );
+
+        // Each rank stores a different subset
+        data.resize(100);
+
+        // Initialize with rank-specific data
+        for (int i = 0; i < 100; i++) {
+          data[i] = rank * 1000 + i;
+        }
+
+        Fenix_Data_member_attr_set(
+          my_group, my_member, FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER, data.data(),
+          &errflag
+        );
+
+        // Each rank stores a different-sized subset
+        // Rank 0: elements [0, 19]   (20 elements)
+        // Rank 1: elements [20, 39]  (20 elements)
+        // Rank 2: elements [40, 59]  (20 elements)
+        // Rank 3: elements [60, 74]  (15 elements)
+        // Rank 4: elements [75, 89]  (15 elements)
+        // Rank 5: elements [90, 99]  (10 elements)
+        int subset_start, subset_end;
+        if (rank < 3) {
+          subset_start = rank * 20;
+          subset_end   = subset_start + 19;
+        } else if (rank < 5) {
+          subset_start = 60 + (rank - 3) * 15;
+          subset_end   = subset_start + 14;
+        } else {
+          subset_start = 90;
+          subset_end   = 99;
+        }
+
+        fprintf(
+          stderr, "Rank %d storing subset [%d, %d]\n", rank, subset_start,
+          subset_end
+        );
+        member_storev(my_group, my_member, {{subset_start, subset_end}});
+        Fenix_Data_commit_barrier(my_group, NULL);
+
+        if (rank == kKillID) {
+          fprintf(stderr, "Doing kill on node %d\n", rank);
+          raise(SIGTERM);
+        }
+      }
+
+      Fenix_Finalize();
+      break;
+    } catch (const fenix::CommException& e) {
+      const fenix::CommException* err = &e;
+      while (true) {
+        try {
+          //We've had a failure! Time to recover data.
+          fprintf(stderr, "Starting data recovery on rank %d\n", rank);
+          fenix_require(err->fenix_err == FENIX_SUCCESS);
+
+          //Repair the group from the spare
+          Fenix_Data_group_create(
+            my_group, res_comm, start_timestamp, group_depth,
+            FENIX_DATA_POLICY_IMR, (int[]){5, 1, 3}, &errflag
+          );
+
+          //Do a null restore to get information about the stored subset
+          DataSubset stored_subset;
+          int ret = member_restore(
+            my_group, my_member, nullptr, 0, FENIX_DATA_SNAPSHOT_LATEST,
+            stored_subset
+          );
+          if (ret != FENIX_SUCCESS) {
+            fprintf(stderr, "Rank %d restore failure w/ code %d\n", rank, ret);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+          }
+
+          fprintf(
+            stderr, "Rank %d restored subset [%zu, %zu]\n", rank,
+            stored_subset.start(), stored_subset.end()
+          );
+
+          //Resize data buffer to fit the restored subset
+          data.resize(100);
+
+          //Set all data to a sentinel value for testing
+          for (int& i : data) i = -999;
+
+          //Now do an lrestore to get the recovered data.
+          // Note: This will throw FENIX_WARNING_PARTIAL_RESTORE because we're
+          // requesting more data than was stored, but that's expected - we
+          // still get the subset that was stored
+          try {
+            ret = member_lrestore(
+              my_group, my_member, data.data(), data.size(),
+              FENIX_DATA_SNAPSHOT_LATEST, stored_subset
+            );
+            if (ret != FENIX_SUCCESS && ret != FENIX_WARNING_PARTIAL_RESTORE) {
+              fprintf(
+                stderr, "Rank %d lrestore failure w/ code %d\n", rank, ret
+              );
+              MPI_Abort(MPI_COMM_WORLD, 1);
+            }
+          } catch (const fenix::RuntimeException& e) {
+            // Expected: partial restore warning because we requested more than
+            // was stored
+            if (e != FENIX_WARNING_PARTIAL_RESTORE) {
+              fprintf(
+                stderr, "Rank %d unexpected exception: %s\n", rank, e.what()
+              );
+              MPI_Abort(MPI_COMM_WORLD, 1);
+            }
+          }
+
+          // Calculate expected subset for this rank
+          int expected_start, expected_end;
+          if (rank < 3) {
+            expected_start = rank * 20;
+            expected_end   = expected_start + 19;
+          } else if (rank < 5) {
+            expected_start = 60 + (rank - 3) * 15;
+            expected_end   = expected_start + 14;
+          } else {
+            expected_start = 90;
+            expected_end   = 99;
+          }
+
+          // Validate that the correct subset was restored
+          fenix_require(
+            stored_subset.start() == expected_start &&
+            stored_subset.end() == expected_end
+          );
+
+          // Validate restored data values in the subset
+          for (int i = expected_start; i <= expected_end; i++) {
+            int expected_value = rank * 1000 + i;
+            fenix_require(data[i] == expected_value);
+          }
+
+          // Verify data outside the subset wasn't touched (should still be
+          // -999)
+          for (int i = 0; i < expected_start; i++) {
+            fenix_require(data[i] == -999);
+          }
+          for (int i = expected_end + 1; i < 100; i++) {
+            fenix_require(data[i] == -999);
+          }
+
+          fprintf(
+            stderr, "SUCCESS: Data restored correctly on rank %d\n", rank
+          );
+          break;
+        } catch (const fenix::CommException& e) {
+          fprintf(
+            stderr, "Nested CommException on rank %d during recovery\n", rank
+          );
+          err          = &e;
+          should_throw = true;
+        }
+      }
+    }
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/test/subset/subset_copy.cpp
+++ b/test/subset/subset_copy.cpp
@@ -64,7 +64,7 @@
 #include <iostream>
 
 #include <fenix.hpp>
-#include "fenix/data/member.hpp"
+#include "fenix/data/snapshot.hpp"
 #include "fenix/data/subset.hpp"
 #include <fenix/data/util/data_ref.hpp>
 #include <fenix/data/util/serializer.hpp>
@@ -107,15 +107,19 @@ bool test_copy(
   in.resize(count);
   out.resize(count);
 
-  DataBuffer b(count);
-
   for (int& i : in) i = default_inval;
   for (int& i : out) i = default_outval;
 
-  DataMember member(0, in.data(), count, sizeof(int), 0, s);
+  // Create snapshot for testing serialization
+  DataSnapshot snap(sizeof(int), count);
+  DataRef in_ref((char*)in.data(), count * sizeof(int));
+  DataRef out_ref((char*)out.data(), count * sizeof(int));
 
-  member.serialize(a, b);
-  member.deserialize(a, b, out);
+  // Serialize from in to snapshot
+  a.copy_data(snap.create_serializer(in_ref, s, a));
+
+  // Deserialize from snapshot to out
+  a.copy_data(snap.create_deserializer(out_ref, s, a));
 
   for (int i = 0; i < count; i++) {
     if (a.includes(i) && out[i] != default_inval) {

--- a/test/subset/subset_pack_data.cpp
+++ b/test/subset/subset_pack_data.cpp
@@ -65,9 +65,8 @@ using fenix::data::util::DataBuffer;
 #include <unistd.h>
 
 #include "fenix/data/subset.hpp"
-using fenix::data::util::DataBuffer;
-#include "fenix/data/member.hpp"
-using fenix::data::util::DataBuffer;
+#include "fenix/data/snapshot.hpp"
+#include "fenix/data/util/data_ref.hpp"
 #include <fenix/data/util/serializer.hpp>
 using fenix::data::util::DataBuffer;
 
@@ -87,22 +86,27 @@ bool test_pack_data(const DataSubset& a) {
   for (int& i : in) i = 1;
   for (int& i : out) i = 0;
 
-  DataBuffer in_buf, out_buf, packed_buf;
+  DataBuffer packed_buf;
+  //fenix::data::util::DataRef in_ref((char*)in.data(), count * sizeof(int));
+  //fenix::data::util::DataRef out_ref((char*)out.data(), count * sizeof(int));
+  std::optional<SerializeFunc> no_func;
 
-  DataMember member(0, in.data(), count, sizeof(int), 0);
+  // Create snapshots for testing
+  DataSnapshot in_snap(sizeof(int), count);
+  DataSnapshot out_snap(sizeof(int), count);
 
-  // Data to in_buf
-  member.serialize(a, in_buf);
+  // Data to in_buf via snapshot
+  a.copy_data(in_snap.create_serializer(in, no_func, a));
 
-  // Pack in_buf into packed_buf
-  a.pack_data(sizeof(int), in_buf, packed_buf);
+  // Pack in_snap.buf() into packed_buf
+  a.pack_data(sizeof(int), in_snap.buf(), packed_buf);
 
-  // Unpack back to out_buf
-  out_buf.reset(sizeof(int) * count);
-  a.unpack_data(sizeof(int), packed_buf, out_buf);
+  // Unpack back to out_snap.buf()
+  out_snap.buf().reset(sizeof(int) * count);
+  a.unpack_data(sizeof(int), packed_buf, out_snap.buf());
 
-  // Data from out_buf to out
-  member.deserialize(a, out_buf, out);
+  // Data from out_snap to out
+  a.copy_data(out_snap.create_deserializer(out, no_func, a));
 
   for (int i = 0; i < count; i++) {
     if (a.includes(i) && out[i] != 1) {


### PR DESCRIPTION
We've had an informal concept of partial-collective operations on a "subgroup" of a group, but with this we can more formally discuss and utilize the concept.

Defining cohorts within a group also lets us centralize more of the logic and further simplify the specific policy implementation details.

DataSnapshots now track the stored/protected subsets for each cohort, which will allow querying cohort information after a shrinking recovery. This was a big part of the motivation for this work: to allow exposing more snapshot information to end-users with the goal of supporting a different form of restore_from_rank.

Adds support for storev with ParityMember, and 2 new tests for that. The new tests further exacerbate the need to clean up the testing directory with more logical testing mechanisms vs ad-hoc tests. It's on the list.